### PR TITLE
LRU eviction for cvefeed.Cache

### DIFF
--- a/cmd/cpe2cve/cpe2cve.go
+++ b/cmd/cpe2cve/cpe2cve.go
@@ -125,6 +125,7 @@ type config struct {
 	skip                      fieldsToSkip
 	indexedDict               bool
 	requireVersion            bool
+	cacheSize                 int
 }
 
 func (c *config) addFlags() {
@@ -132,6 +133,7 @@ func (c *config) addFlags() {
 	flag.IntVar(&c.cpesAt, "cpe", 0, "look for CPE names in input at this position (starts with 1)")
 	flag.IntVar(&c.cvesAt, "cve", 0, "output CVEs at this position (starts with 1)")
 	flag.IntVar(&c.matchesAt, "matches", 0, "output CPEs that matches CVE at this position; 0 disables the output")
+	flag.IntVar(&c.cacheSize, "cache_size", 0, "limit the cache size to this amount in bytes; 0 removes the limit, -1 disables caching")
 	flag.StringVar(&c.feedFormat, "feed", "xml", "vulnerability feed format (currently xml and json values are supported")
 	flag.StringVar(&c.inFieldSep, "d", "\t", "input columns delimiter")
 	flag.StringVar(&c.inRecSep, "d2", ",", "inner input columns delimiter: separates elements of list passed into a CSV columns")
@@ -305,7 +307,7 @@ func main() {
 	}
 	glog.V(1).Infof("...done in %v", time.Since(start))
 
-	cache := cvefeed.NewCache(dict, cfg.requireVersion)
+	cache := cvefeed.NewCache(dict).SetRequireVersion(cfg.requireVersion).SetMaxSize(cfg.cacheSize)
 
 	if cfg.indexedDict {
 		start = time.Now()

--- a/cmd/cpe2cve/cpe2cve_test.go
+++ b/cmd/cpe2cve/cpe2cve_test.go
@@ -74,12 +74,12 @@ func TestProcessInput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't parse XML dictionary: %v", err)
 	}
-	cacheXML := cvefeed.NewCache(testDictXML, false)
+	cacheXML := cvefeed.NewCache(testDictXML)
 	testDictJSON, err := cvefeed.ParseJSON(strings.NewReader(testDictJSONStr))
 	if err != nil {
 		t.Fatalf("couldn't parse JSON dictionary: %v", err)
 	}
-	cacheJSON := cvefeed.NewCache(testDictJSON, false)
+	cacheJSON := cvefeed.NewCache(testDictJSON)
 	cfg := config{
 		nProcessors: 2,
 		cpesAt:      4,
@@ -128,7 +128,7 @@ func TestProcessInputFalsePositives(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't parse JSON dictionary: %v", err)
 	}
-	cache := cvefeed.NewCache(dict, false)
+	cache := cvefeed.NewCache(dict)
 	cfg := config{
 		nProcessors: 2,
 		cpesAt:      1,
@@ -155,7 +155,7 @@ func TestProcessInputRequireVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't parse JSON dictionary: %v", err)
 	}
-	cache := cvefeed.NewCache(dict, true)
+	cache := cvefeed.NewCache(dict).SetRequireVersion(true)
 	cfg := config{
 		nProcessors:    2,
 		cpesAt:         1,
@@ -186,7 +186,7 @@ func BenchmarkProcessInputXML(t *testing.B) {
 	if err != nil {
 		t.Fatalf("couldn't parse dictionary: %v", err)
 	}
-	cache := cvefeed.NewCache(testDict, false)
+	cache := cvefeed.NewCache(testDict)
 	cfg := config{
 		nProcessors: 1,
 		cpesAt:      4,
@@ -217,7 +217,7 @@ func BenchmarkProcessInputJSON(t *testing.B) {
 	if err != nil {
 		t.Fatalf("couldn't parse dictionary: %v", err)
 	}
-	cache := cvefeed.NewCache(testDict, false)
+	cache := cvefeed.NewCache(testDict)
 	cfg := config{
 		nProcessors: 1,
 		cpesAt:      4,

--- a/cvefeed/cvecache.go
+++ b/cvefeed/cvecache.go
@@ -18,9 +18,12 @@ import (
 	"bytes"
 	"sort"
 	"sync"
+	"unsafe"
 
 	"github.com/facebookincubator/nvdtools/wfn"
 )
+
+const CacheEvictPercentage = 0.1 // every eviction cycle invalidates this part of cache size at once
 
 // Index maps the CPEs to the entries in the NVD feed they mentioned in
 type Index map[string][]CVEItem
@@ -68,61 +71,125 @@ type MatchResult struct {
 	CPEs []*wfn.Attributes
 }
 
-// cachedCVEs stores cached CVEs + a channel to signal if the value is ready
+// cachedCVEs stores cached CVEs, a channel to signal if the value is ready
 type cachedCVEs struct {
-	res   []MatchResult
-	ready chan struct{}
+	res           []MatchResult
+	ready         chan struct{}
+	size          int
+	evictionIndex int // position in eviction queue
+}
+
+// updateResSize calculates the size of cached MatchResult and assigns it to cves.size
+func (cves *cachedCVEs) updateResSize(key string) {
+	cves.size = int(unsafe.Sizeof(key)) + len(key)
+	if cves == nil {
+		return
+	}
+	cves.size += int(unsafe.Sizeof(cves.res))
+	for i := range cves.res {
+		cves.size += int(unsafe.Sizeof(cves.res[i].CVE)) + len(cves.res[i].CVE)
+		for _, attr := range cves.res[i].CPEs {
+			cves.size += len(attr.Part) + int(unsafe.Sizeof(attr.Part))
+			cves.size += len(attr.Vendor) + int(unsafe.Sizeof(attr.Vendor))
+			cves.size += len(attr.Product) + int(unsafe.Sizeof(attr.Product))
+			cves.size += len(attr.Version) + int(unsafe.Sizeof(attr.Version))
+			cves.size += len(attr.Update) + int(unsafe.Sizeof(attr.Update))
+			cves.size += len(attr.Edition) + int(unsafe.Sizeof(attr.Edition))
+			cves.size += len(attr.SWEdition) + int(unsafe.Sizeof(attr.SWEdition))
+			cves.size += len(attr.TargetHW) + int(unsafe.Sizeof(attr.TargetHW))
+			cves.size += len(attr.Other) + int(unsafe.Sizeof(attr.Other))
+			cves.size += len(attr.Language) + int(unsafe.Sizeof(attr.Language))
+		}
+	}
 }
 
 // Cache caches CVEs for known CPEs
 type Cache struct {
 	data           map[string]*cachedCVEs
+	evictionQ      *evictionQueue
 	mu             sync.Mutex
 	Dict           Dictionary
 	Idx            Index
-	requireVersion bool // ignore matching specifications that have Version == ANY
+	RequireVersion bool // ignore matching specifications that have Version == ANY
+	MaxSize        int  // maximum size of the cache, 0 -- unlimited, -1 -- no caching
+	size           int  // current size of the cache
 }
 
-// NewCache creates new Cache instance with dictionary dict
-func NewCache(dict Dictionary, requireVersion bool) *Cache {
-	return &Cache{
-		Dict:           dict,
-		requireVersion: requireVersion,
-	}
+// NewCache creates new Cache instance with dictionary dict.
+func NewCache(dict Dictionary) *Cache {
+	return &Cache{Dict: dict, evictionQ: new(evictionQueue)}
 }
 
-// Get returns slice of CVEs for CPE names from cpes parameter; if CVEs aren't cached
-// if finds them in cveDict and caches the results
-func (vc *Cache) Get(cpes []*wfn.Attributes) []MatchResult {
-	key := cacheKey(cpes)
-	vc.mu.Lock()
-	if vc.data == nil {
-		vc.data = make(map[string]*cachedCVEs)
-	}
-	cves := vc.data[key]
-	if cves == nil {
-		// first request; the goroutine that sent it computes the value
-		cves = &cachedCVEs{ready: make(chan struct{})}
-		vc.data[key] = cves
-		vc.mu.Unlock()
-		// now other requests for this key wait on the channel, and the other requests aren't blocked
-		if vc.Idx == nil {
-			cves.res = vc.match(cpes, vc.Dict)
+// SetRequireVersion sets if the instance of cache fails matching the dictionary
+// records without Version attribute of CPE name.
+// Returns a pointer to the instance of Cache, for easy chaining.
+func (c *Cache) SetRequireVersion(requireVersion bool) *Cache {
+	c.RequireVersion = requireVersion
+	return c
+}
+
+// SetMaxSize sets maximum size of the cache to some pre-defined value,
+// size of 0 disables eviction (makes the cache grow indefinitely),
+// negative size disables caching.
+// Returns a pointer to the instance of Cache, for easy chaining.
+func (c *Cache) SetMaxSize(size int) *Cache {
+	c.MaxSize = size
+	return c
+}
+
+// Get returns slice of CVEs for CPE names from cpes parameter;
+// if CVEs aren't cached (and the feature is enabled) it finds them in cveDict and caches the results
+func (c *Cache) Get(cpes []*wfn.Attributes) []MatchResult {
+	// negative max size of the cache disables caching
+	if c.MaxSize < 0 {
+		if c.Idx == nil {
+			return c.match(cpes, c.Dict)
 		} else {
-			cves.res = vc.match(cpes, vc.dictFromIndex(cpes))
+			return c.match(cpes, c.dictFromIndex(cpes))
 		}
-		close(cves.ready)
-	} else {
-		// value is being computed, wait till ready
-		vc.mu.Unlock()
-		<-cves.ready
 	}
+
+	// otherwise, let's get to the business
+	key := cacheKey(cpes)
+	c.mu.Lock()
+	if c.data == nil {
+		c.data = make(map[string]*cachedCVEs)
+	}
+	cves := c.data[key]
+	if cves != nil {
+		// value is being computed, wait till ready
+		c.mu.Unlock()
+		<-cves.ready
+		c.mu.Lock() // TODO: XXX: ugly, consider using atomic.Value instead
+		cves.evictionIndex = c.evictionQ.touch(cves.evictionIndex)
+		c.mu.Unlock()
+		return cves.res
+	}
+	// first request; the goroutine that sent it computes the value
+	cves = &cachedCVEs{ready: make(chan struct{})}
+	c.data[key] = cves
+	c.mu.Unlock()
+	// now other requests for same key wait on the channel, and the requests for the different keys aren't blocked
+	if c.Idx == nil {
+		cves.res = c.match(cpes, c.Dict)
+	} else {
+		cves.res = c.match(cpes, c.dictFromIndex(cpes))
+	}
+	cves.updateResSize(key)
+	c.mu.Lock()
+	c.size += cves.size
+	if c.MaxSize != 0 && c.size > c.MaxSize {
+		c.evict(int(CacheEvictPercentage * float64(c.MaxSize)))
+	}
+	cves.evictionIndex = c.evictionQ.push(key)
+	c.mu.Unlock()
+	close(cves.ready)
 	return cves.res
 }
 
 // dictFromIndex creates CVE dictionary from entries indexed by CPE names
-func (vc *Cache) dictFromIndex(cpes []*wfn.Attributes) Dictionary {
-	if vc.Idx == nil {
+func (c *Cache) dictFromIndex(cpes []*wfn.Attributes) Dictionary {
+	if c.Idx == nil {
 		return nil
 	}
 	d := Dictionary{}
@@ -135,10 +202,10 @@ func (vc *Cache) dictFromIndex(cpes []*wfn.Attributes) Dictionary {
 		if product == wfn.Any {
 			continue
 		}
-		if _, ok := vc.Idx[product]; !ok {
+		if _, ok := c.Idx[product]; !ok {
 			continue
 		}
-		for _, e := range vc.Idx[product] {
+		for _, e := range c.Idx[product] {
 			if _, ok := knownEntries[e]; ok {
 				continue
 			}
@@ -146,7 +213,7 @@ func (vc *Cache) dictFromIndex(cpes []*wfn.Attributes) Dictionary {
 			d = append(d, e)
 		}
 	}
-	for _, e := range vc.Idx[wfn.Any] {
+	for _, e := range c.Idx[wfn.Any] {
 		if _, ok := knownEntries[e]; ok {
 			continue
 		}
@@ -157,14 +224,28 @@ func (vc *Cache) dictFromIndex(cpes []*wfn.Attributes) Dictionary {
 }
 
 // match matches the CPE names against internal vulnerability dictionary and returns a slice of matching resutls
-func (vc *Cache) match(cpes []*wfn.Attributes, dict Dictionary) (result []MatchResult) {
+func (c *Cache) match(cpes []*wfn.Attributes, dict Dictionary) (result []MatchResult) {
 	for _, v := range dict {
-		if mm, ok := Match(cpes, v.Config(), vc.requireVersion); ok {
+		if mm, ok := Match(cpes, v.Config(), c.RequireVersion); ok {
 			mm = uniq(mm)
 			result = append(result, MatchResult{v.CVEID(), mm})
 		}
 	}
 	return result
+}
+
+// evict the least recently used records untile nbytes of capacity is achieved or no more records left.
+// It is not concurrency-safe, c.mu should be locked before calling it.
+func (c *Cache) evict(nbytes int) {
+	for c.size+nbytes > c.MaxSize {
+		key := c.evictionQ.pop()
+		cd, ok := c.data[key]
+		if !ok { // should not happen
+			panic("attempted to evict non-existent record")
+		}
+		c.size -= cd.size
+		delete(c.data, key)
+	}
 }
 
 func cacheKey(cpes []*wfn.Attributes) string {

--- a/cvefeed/eviction_test.go
+++ b/cvefeed/eviction_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cvefeed
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/facebookincubator/nvdtools/wfn"
+)
+
+func TestCacheEviction(t *testing.T) {
+	items, err := ParseJSON(bytes.NewBufferString(testJSONdict))
+	if err != nil {
+		t.Fatalf("failed to parse the dictionary: %v", err)
+	}
+	cache := NewCache(items).SetMaxSize(2 * 1024)
+	matchingItem := &wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "5\\.4"}
+
+	// first, run concurrently and enjoy different sizes of cache logged on each run
+	var wg sync.WaitGroup
+	wg.Add(40)
+	for i := 0; i < 40; i++ {
+		go func(variant int) {
+			defer wg.Done()
+			inventory := []*wfn.Attributes{
+				matchingItem,
+			}
+			for i := 0; i < variant; i++ {
+				inventory = append(inventory, &wfn.Attributes{Vendor: "huh", Product: "brah"})
+			}
+			matches := cache.Get(inventory)
+			if len(matches) != 1 {
+				t.Errorf("variant %d: cache.Get() returned wrong amount of matches (%d, 1 was expected)", variant, len(matches))
+			}
+			if len(matches[0].CPEs) != 1 {
+				t.Errorf("variant %d: cache.Get() returned wrong a match with wrong number of CPEs (%d, 1 was expected)", variant, len(matches[0].CPEs))
+			}
+			if *matches[0].CPEs[0] != *matchingItem {
+				t.Errorf("variant %d: cache.Get() returned wrong match:\n%+v\n%+v was expected", variant, *matches[0].CPEs[0], *matchingItem)
+			}
+		}(i)
+	}
+	wg.Wait()
+	if cache.size > cache.MaxSize {
+		t.Errorf("concurrent run: cache size exceeds maximum: %d bytes out of %d bytes", cache.size, cache.MaxSize)
+	}
+	t.Logf("concurrent run: cache size %d/%d; %d records cached", cache.size, cache.MaxSize, len(cache.data))
+
+	// now let's get serious and get some deterministic resutls
+	for i := 0; i < 40; i++ {
+		variant := i
+		inventory := []*wfn.Attributes{
+			matchingItem,
+		}
+		for i := 0; i < variant; i++ {
+			inventory = append(inventory, &wfn.Attributes{Vendor: "huh", Product: "brah"})
+		}
+		matches := cache.Get(inventory)
+		if len(matches) != 1 {
+			t.Errorf("variant %d: cache.Get() returned wrong amount of matches (%d, 1 was expected)", variant, len(matches))
+		}
+		if len(matches[0].CPEs) != 1 {
+			t.Errorf("variant %d: cache.Get() returned wrong a match with wrong number of CPEs (%d, 1 was expected)", variant, len(matches[0].CPEs))
+		}
+		if *matches[0].CPEs[0] != *matchingItem {
+			t.Errorf("variant %d: cache.Get() returned wrong match:\n%+v\n%+v was expected", variant, *matches[0].CPEs[0], *matchingItem)
+		}
+	}
+	if cache.size > cache.MaxSize {
+		t.Errorf("sequential run #1: cache size exceeds maximum: %d bytes out of %d bytes", cache.size, cache.MaxSize)
+	}
+	// the latest cached items are almost 1K long, so there should be only 1 left in the cache
+	if len(cache.data) > 1 {
+		t.Errorf("sequential run #1: more than 1 record cached (%d)", len(cache.data))
+	}
+	t.Logf("sequential run #1: cache size %d/%d; %d records cached", cache.size, cache.MaxSize, len(cache.data))
+
+	// and now let's go the other way around and make cache evict the bigger records first
+	for i := 39; i >= 0; i-- {
+		variant := i
+		inventory := []*wfn.Attributes{
+			matchingItem,
+		}
+		for i := 0; i < variant; i++ {
+			inventory = append(inventory, &wfn.Attributes{Vendor: "huh", Product: "brah"})
+		}
+		matches := cache.Get(inventory)
+		if len(matches) != 1 {
+			t.Errorf("variant %d: cache.Get() returned wrong amount of matches (%d, 1 was expected)", variant, len(matches))
+		}
+		if len(matches[0].CPEs) != 1 {
+			t.Errorf("variant %d: cache.Get() returned wrong a match with wrong number of CPEs (%d, 1 was expected)", variant, len(matches[0].CPEs))
+		}
+		if *matches[0].CPEs[0] != *matchingItem {
+			t.Errorf("variant %d: cache.Get() returned wrong match:\n%+v\n%+v was expected", variant, *matches[0].CPEs[0], *matchingItem)
+		}
+	}
+	if cache.size > cache.MaxSize {
+		t.Errorf("sequential run #2: cache size exceeds maximum: %d bytes out of %d bytes", cache.size, cache.MaxSize)
+	}
+	// Since we touch the smaller records first, we should have more of these cached
+	if len(cache.data) < 5 {
+		t.Errorf("sequential run #2: more than 1 record cached (%d)", len(cache.data))
+	}
+	t.Logf("sequentual run #2: cache size %d/%d; %d records cached", cache.size, cache.MaxSize, len(cache.data))
+}

--- a/cvefeed/evictionqueue.go
+++ b/cvefeed/evictionqueue.go
@@ -1,0 +1,84 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cvefeed
+
+import (
+	"container/heap"
+	"time"
+)
+
+type evictionData struct {
+	key    string    // which key in Cache.data refers to it
+	index  int       // the index of item on the heap
+	access time.Time // last access time
+}
+
+// evictionQueue is a priority queue for LRU cache
+type evictionQueue struct {
+	q evictionHeap
+}
+
+// pop pops next key to evict
+func (eq *evictionQueue) pop() string {
+	if eq.q.Len() > 0 {
+		return heap.Pop(&eq.q).(*evictionData).key
+	}
+	return ""
+}
+
+// push pushes a key onto heap, returns the index item ended up at.
+func (eq *evictionQueue) push(key string) int {
+	index := eq.q.Len()
+	ed := &evictionData{
+		key:    key,
+		index:  index,
+		access: time.Now(),
+	}
+	heap.Push(&eq.q, ed)
+	return ed.index
+}
+
+// touch updates the access time of the item at index, returns the new index of that item.
+func (eq *evictionQueue) touch(index int) int {
+	ed := eq.q[index]
+	ed.access = time.Now()
+	heap.Fix(&eq.q, index)
+	return ed.index
+}
+
+// evictionHeap is a slice of evictionData that implements heap.Interface
+type evictionHeap []*evictionData
+
+func (eh evictionHeap) Len() int { return len(eh) }
+
+func (eh evictionHeap) Less(i, j int) bool { return eh[i].access.Before(eh[j].access) }
+
+func (eh evictionHeap) Swap(i, j int) {
+	eh[i], eh[j] = eh[j], eh[i]
+	eh[i].index, eh[j].index = i, j
+}
+
+func (eh *evictionHeap) Push(x interface{}) {
+	ed := x.(*evictionData)
+	ed.index = len(*eh)
+	*eh = append(*eh, ed)
+}
+
+func (eh *evictionHeap) Pop() interface{} {
+	old := *eh
+	ed := old[len(old)-1]
+	*eh = old[:len(old)-1]
+	return ed
+}

--- a/cvefeed/evictionqueue_test.go
+++ b/cvefeed/evictionqueue_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cvefeed
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEvictionQueue(t *testing.T) {
+	var q evictionQueue
+	cases := []string{"hello", "world", "quux", "baz", "foo"}
+	for i, c := range cases {
+		idx := q.push(c)
+		if idx != i {
+			t.Errorf("push() returned wrong index %d (%d was expected)", idx, i)
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	// first, it should appear in order
+	for i := range cases {
+		if cases[i] != q.q[i].key {
+			t.Errorf("unexpected queue order (before touch-ing):\nexpected %v\ngot      %v", cases, listKeys(q.q))
+			break
+		}
+	}
+
+	// touch it in reverse order
+	for i := len(cases) - 1; i >= 0; i-- {
+		q.touch(i)
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	// now baz and quux should be after foo and hello and world should be the last ones
+	// but the exact order is non-deterministic
+	for i, item := range q.q {
+		switch i {
+		case 0:
+			if item.key != "foo" {
+				t.Errorf("unexpected queue order (after touch-ing): %q at position %d", item.key, i)
+			}
+		case 1, 2:
+			if item.key != "baz" && item.key != "quux" {
+				t.Errorf("unexpected queue order (after touch-ing): %q at position %d", item.key, i)
+			}
+		case 3, 4:
+			if item.key != "hello" && item.key != "world" {
+				t.Errorf("unexpected queue order (after touch-ing): %q at position %d", item.key, i)
+			}
+		default:
+			t.Fatal("unreacheable code reached o_O")
+		}
+	}
+
+	// but when pop-ing the values from heap, it should come in order reverse to the one we started with
+	for i := len(cases) - 1; i >= 0; i-- {
+		item := q.pop()
+		if item != cases[i] {
+			t.Errorf("unexpected queue order (while pop-ing):\nexpected %v\ngot      %v", cases, listKeys(q.q))
+			break
+		}
+	}
+}
+
+func listKeys(in []*evictionData) []string {
+	out := make([]string, len(in))
+	for i, item := range in {
+		out[i] = item.key
+	}
+	return out
+}

--- a/cvefeed/matching_json_test.go
+++ b/cvefeed/matching_json_test.go
@@ -69,7 +69,7 @@ func TestMatchJSON(t *testing.T) {
 			Expect: true,
 		},
 	}
-	items, err := ParseJSON(bytes.NewBufferString(dict))
+	items, err := ParseJSON(bytes.NewBufferString(testJSONdict))
 	if err != nil {
 		t.Fatalf("failed to parse the dictionary: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestMatchJSONrequireVersion(t *testing.T) {
 	inventory := []*wfn.Attributes{
 		&wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
 	}
-	items, err := ParseJSON(bytes.NewBufferString(dict))
+	items, err := ParseJSON(bytes.NewBufferString(testJSONdict))
 	if err != nil {
 		t.Fatalf("failed to parse the dictionary: %v", err)
 	}
@@ -105,7 +105,7 @@ func BenchmarkMatchJSON(b *testing.B) {
 		&wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
 		&wfn.Attributes{Part: "a", Vendor: "facebook", Product: "styx", Version: "0\\.1"},
 	}
-	items, err := ParseJSON(bytes.NewBufferString(dict))
+	items, err := ParseJSON(bytes.NewBufferString(testJSONdict))
 	if err != nil {
 		b.Fatalf("failed to parse the dictionary: %v", err)
 	}
@@ -117,7 +117,7 @@ func BenchmarkMatchJSON(b *testing.B) {
 	}
 }
 
-var dict = `{
+var testJSONdict = `{
 "CVE_data_type" : "CVE",
 "CVE_data_format" : "MITRE",
 "CVE_data_version" : "4.0",


### PR DESCRIPTION
This should fix #3.

Unittests output for the feature:
```
dalgo@dxps:~/go/src/github.com/facebookincubator/nvdtools/cvefeed$ go test -v
=== RUN   TestCacheEviction
--- PASS: TestCacheEviction (0.01s)
    eviction_test.go:61: concurrent run: cache size 1594/2048; 2 records cached
    eviction_test.go:90: sequential run #1: cache size 977/2048; 1 records cached
    eviction_test.go:119: sequentual run #2: cache size 1555/2048; 5 records cached
=== RUN   TestEvictionQueue
--- PASS: TestEvictionQueue (0.01s)

# ... pew-pew, skipped unrelated ...

PASS
ok      github.com/facebookincubator/nvdtools/cvefeed   0.019s

```

And overall:
```
dalgo@dxps:~/go/src/github.com/facebookincubator/nvdtools$ go test ./...
ok      github.com/facebookincubator/nvdtools/cmd/cpe2cve       0.027s
ok      github.com/facebookincubator/nvdtools/cmd/csv2cpe       0.029s
?       github.com/facebookincubator/nvdtools/cmd/nvdsync       [no test files]
ok      github.com/facebookincubator/nvdtools/cmd/nvdsync/datafeed      0.070s
ok      github.com/facebookincubator/nvdtools/cmd/rpm2cpe       0.021s
ok      github.com/facebookincubator/nvdtools/cpedict   0.009s
ok      github.com/facebookincubator/nvdtools/cpeparse  0.010s
ok      github.com/facebookincubator/nvdtools/cvefeed   0.015s
?       github.com/facebookincubator/nvdtools/cvefeed/internal/iface    [no test files]
?       github.com/facebookincubator/nvdtools/cvefeed/internal/nvdjson  [no test files]
?       github.com/facebookincubator/nvdtools/cvefeed/internal/nvdxml   [no test files]
ok      github.com/facebookincubator/nvdtools/wfn       0.002s
```
