### PR TITLE
Identify source RPM packages as suitable for any hardware architecture.

### DIFF
--- a/cpeparse/rpmname.go
+++ b/cpeparse/rpmname.go
@@ -34,7 +34,7 @@ func FieldsFromRPMName(s string) (name, ver, rel, arch string, err error) {
 			err = fmt.Errorf("couldn't parse architecture from RPM package name %q: %v", s, err)
 			return
 		}
-		if arch == "noarch" {
+		if arch == "noarch" || arch == "src" {
 			arch = wfn.Any
 		}
 		pkg = pkg[:i]

--- a/cpeparse/rpmname_test.go
+++ b/cpeparse/rpmname_test.go
@@ -27,6 +27,7 @@ func TestFromRPMName(t *testing.T) {
 		{"name-1.0.1.rmp", "", true},
 		{"name-1.0-1.noarch.rpm", "cpe:2.3:a:*:name:1.0:1:*:*:*:*:*:*", false},
 		{"NaMe-1.0-1.i386.rpm", "cpe:2.3:a:*:name:1.0:1:*:*:*:*:i386:*", false},
+		{"NaMe-1.0-1.src.rpm", "cpe:2.3:a:*:name:1.0:1:*:*:*:*:*:*", false},
 	}
 	for _, c := range cases {
 		attr, err := FromRPMName(c.pkgName)


### PR DESCRIPTION
TL;DR:
```
$ echo "cdp-0.33-3.src.rpm" | rpm2cpe -cpe 2 -rpm 1
cdp-0.33-3.src.rpm      cpe:/a::cdp:0.33:3:~~~~src~
```

should instead be

```
$ echo "cdp-0.33-3.src.rpm" | rpm2cpe -cpe 2 -rpm 1
cdp-0.33-3.src.rpm      cpe:/a::cdp:0.33:3
```

which this patch delivers.