### PR TITLE
Enable setting UserAgent from cmdline in nvdsync

### DIFF
--- a/cmd/nvdsync/datafeed/http.go
+++ b/cmd/nvdsync/datafeed/http.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 )
 
+var UserAgent string
+
 // http helpers
 
 func httpNewRequestContext(ctx context.Context, method, path string) (*http.Request, error) {
@@ -29,7 +31,7 @@ func httpNewRequestContext(ctx context.Context, method, path string) (*http.Requ
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", "nvdsync-"+Version)
+	req.Header.Set("User-Agent", UserAgent)
 	return req.WithContext(ctx), nil
 }
 

--- a/cmd/nvdsync/main.go
+++ b/cmd/nvdsync/main.go
@@ -63,13 +63,12 @@ func main() {
 	}
 
 	// determine User-Agent header
-	re := regexp.MustCompile("[[:^ascii:]]")
-	ua_ascii := re.ReplaceAllLiteralString(*ua, "")
-	if ua_ascii != *ua {
+	// check if it's only ascii characters
+	if regexp.MustCompile("^[[:ascii:]]+$").MatchString(*ua) {
+		datafeed.UserAgent = *ua
+	} else {
 		glog.Warning("User-Agent contains non ascii characters, using default")
 		datafeed.UserAgent = default_ua
-	} else {
-		datafeed.UserAgent = *ua
 	}
 	glog.Infof("Using http User-Agent: %s", datafeed.UserAgent)
 


### PR DESCRIPTION
Test Plan: Used `fmt.Print` to print the UserAgent inside the `httpNewRequestContext` function. `-user_agent` worked as expected, default value is the same as it was before