### PR TITLE
Cosmetics/linter:

### DIFF
--- a/cmd/nvdsync/datafeed/http.go
+++ b/cmd/nvdsync/datafeed/http.go
@@ -20,9 +20,10 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"regexp"
 )
 
-var UserAgent string
+var userAgent = "nvdsync-" + Version
 
 // http helpers
 
@@ -31,7 +32,7 @@ func httpNewRequestContext(ctx context.Context, method, path string) (*http.Requ
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", UserAgent)
+	req.Header.Set("User-Agent", UserAgent())
 	return req.WithContext(ctx), nil
 }
 
@@ -45,4 +46,18 @@ func httpResponseNotOK(resp *http.Response) error {
 	}
 	return fmt.Errorf("unexpected http response from %q (%q): %q",
 		resp.Request.URL.String(), resp.Status, string(body))
+}
+
+// SetUserAgent sets the value of User-Agent HTTP header for the client
+func SetUserAgent(ua string) error {
+	if !regexp.MustCompile("^[[:ascii:]]+$").MatchString(ua) {
+		return fmt.Errorf("non-ascii character in User-Agent header: %q", ua)
+	}
+	userAgent = ua
+	return nil
+}
+
+// UserAgent returns the value of User-Agent HTTP header used by the client
+func UserAgent() string {
+	return userAgent
 }

--- a/cmd/rpm2cpe/rpm2cpe_test.go
+++ b/cmd/rpm2cpe/rpm2cpe_test.go
@@ -32,12 +32,12 @@ func TestSkipFields(t *testing.T) {
 			out: []string{"0", "1", "2", "3", "4", "5"},
 		},
 		{
-			f2s: fieldsToSkip(map[int]struct{}{1: struct{}{}, 3: struct{}{}}),
+			f2s: fieldsToSkip(map[int]struct{}{1: {}, 3: {}}),
 			in:  []string{"0", "1", "2", "3", "4", "5"},
 			out: []string{"0", "2", "4", "5"},
 		},
 		{
-			f2s: fieldsToSkip(map[int]struct{}{0: struct{}{}, 1: struct{}{}, 2: struct{}{}}),
+			f2s: fieldsToSkip(map[int]struct{}{0: {}, 1: {}, 2: {}}),
 			in:  []string{"0", "1", "2"},
 			out: []string{},
 		},
@@ -67,7 +67,7 @@ func TestProcessRecord(t *testing.T) {
 		cpeField:    5,
 		inFieldSep:  ",",
 		outFieldSep: ";",
-		skip:        fieldsToSkip(map[int]struct{}{0: struct{}{}, 3: struct{}{}}),
+		skip:        fieldsToSkip(map[int]struct{}{0: {}, 3: {}}),
 	}
 	for _, c := range cases {
 		record, err := processRecord(strings.Split(c.in, cfg.inFieldSep), cfg)
@@ -78,7 +78,7 @@ func TestProcessRecord(t *testing.T) {
 			continue
 		}
 		if c.fail {
-			t.Errorf("line %q was expected to fail, but succeded", c.in)
+			t.Errorf("line %q was expected to fail, but succeeded", c.in)
 			continue
 		}
 		out := strings.Join(record, cfg.outFieldSep)

--- a/cpedict/cpedict.go
+++ b/cpedict/cpedict.go
@@ -110,7 +110,7 @@ type CPEItem struct {
 	Notes           TextType     `xml:"notes"`
 	References      []Reference  `xml:"references>reference"`
 	// Calls out a check, such as an OVAL definition, that can confirm or reject
-	// an IT system as an instance of the named platform. 0-n occurances.
+	// an IT system as an instance of the named platform. 0-n occurrences.
 	// TODO: not implemented
 	Check struct{} `xml:"check"`
 }

--- a/cpedict/lookup.go
+++ b/cpedict/lookup.go
@@ -49,7 +49,7 @@ func (mt MatchType) String() string {
 
 // Search determinces how WFN (NamePattern) relates the given dictionary.
 // Deprecated matching names are resolved to their replacements; since item can be deprecated by multiple
-// names, wich might contain wildcards and in general refer to the whole family of products, this resolve isn't
+// names, which might contain wildcards and in general refer to the whole family of products, this resolve isn't
 // performed during exact match.
 // If exact is true and an exact match is found, the function will return the match and match type of Exact.
 // If the needle is a superset of any of the dictionary names, the function  will return that set of names

--- a/cvefeed/matching_json_test.go
+++ b/cvefeed/matching_json_test.go
@@ -36,35 +36,35 @@ func TestMatchJSON(t *testing.T) {
 		},
 		{
 			Inventory: []*wfn.Attributes{
-				&wfn.Attributes{Part: "o", Vendor: "linux", Product: "linux_kernel", Version: "2\\.6\\.1"},
-				&wfn.Attributes{Part: "a", Vendor: "djvulibre_project", Product: "djvulibre", Version: "3\\.5\\.11"},
+				{Part: "o", Vendor: "linux", Product: "linux_kernel", Version: "2\\.6\\.1"},
+				{Part: "a", Vendor: "djvulibre_project", Product: "djvulibre", Version: "3\\.5\\.11"},
 			},
 			Expect: false,
 		},
 		{
 			Rule: 0,
 			Inventory: []*wfn.Attributes{
-				&wfn.Attributes{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
-				&wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
-				&wfn.Attributes{Part: "a", Vendor: "facebook", Product: "styx", Version: "0\\.1"},
+				{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
+				{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
+				{Part: "a", Vendor: "facebook", Product: "styx", Version: "0\\.1"},
 			},
 			Matches: []*wfn.Attributes{
-				&wfn.Attributes{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
-				&wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
+				{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
+				{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
 			},
 			Expect: true,
 		},
 		{
 			Rule: 1,
 			Inventory: []*wfn.Attributes{
-				&wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "3\\.9"},
-				&wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "4\\.0"},
-				&wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "5\\.4"},
-				&wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
+				{Part: "a", Vendor: "microsoft", Product: "ie", Version: "3\\.9"},
+				{Part: "a", Vendor: "microsoft", Product: "ie", Version: "4\\.0"},
+				{Part: "a", Vendor: "microsoft", Product: "ie", Version: "5\\.4"},
+				{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
 			},
 			Matches: []*wfn.Attributes{
-				&wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "4\\.0"},
-				&wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "5\\.4"},
+				{Part: "a", Vendor: "microsoft", Product: "ie", Version: "4\\.0"},
+				{Part: "a", Vendor: "microsoft", Product: "ie", Version: "5\\.4"},
 			},
 			Expect: true,
 		},
@@ -88,7 +88,7 @@ func TestMatchJSON(t *testing.T) {
 
 func TestMatchJSONrequireVersion(t *testing.T) {
 	inventory := []*wfn.Attributes{
-		&wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
+		{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
 	}
 	items, err := ParseJSON(bytes.NewBufferString(testJSONdict))
 	if err != nil {
@@ -101,9 +101,9 @@ func TestMatchJSONrequireVersion(t *testing.T) {
 
 func BenchmarkMatchJSON(b *testing.B) {
 	inventory := []*wfn.Attributes{
-		&wfn.Attributes{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
-		&wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
-		&wfn.Attributes{Part: "a", Vendor: "facebook", Product: "styx", Version: "0\\.1"},
+		{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
+		{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
+		{Part: "a", Vendor: "facebook", Product: "styx", Version: "0\\.1"},
 	}
 	items, err := ParseJSON(bytes.NewBufferString(testJSONdict))
 	if err != nil {

--- a/cvefeed/matching_xml_test.go
+++ b/cvefeed/matching_xml_test.go
@@ -47,8 +47,8 @@ func TestMatchXML(t *testing.T) {
 		},
 		{
 			Inventory: []*wfn.Attributes{
-				&wfn.Attributes{Part: "o", Vendor: "linux", Product: "linux_kernel", Version: "2\\.6\\.1"},
-				&wfn.Attributes{Part: "a", Vendor: "djvulibre_project", Product: "djvulibre", Version: "3\\.5\\.11"},
+				{Part: "o", Vendor: "linux", Product: "linux_kernel", Version: "2\\.6\\.1"},
+				{Part: "a", Vendor: "djvulibre_project", Product: "djvulibre", Version: "3\\.5\\.11"},
 			},
 			Dict: `
 				<vuln:vulnerable-configuration id="http://nvd.nist.gov/">
@@ -65,9 +65,9 @@ func TestMatchXML(t *testing.T) {
 		},
 		{
 			Inventory: []*wfn.Attributes{
-				&wfn.Attributes{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
-				&wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
-				&wfn.Attributes{Part: "a", Vendor: "facebook", Product: "styx", Version: "0\\.1"},
+				{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
+				{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
+				{Part: "a", Vendor: "facebook", Product: "styx", Version: "0\\.1"},
 			},
 			Dict: `
 				<vuln:vulnerable-configuration id="http://nvd.nist.gov/">
@@ -81,16 +81,16 @@ func TestMatchXML(t *testing.T) {
 					</cpe-lang:logical-test>
 				</vuln:vulnerable-configuration>`,
 			Matches: []*wfn.Attributes{
-				&wfn.Attributes{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
-				&wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
+				{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
+				{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
 			},
 			Expect: true,
 		},
 		{
 			Inventory: []*wfn.Attributes{
-				&wfn.Attributes{Part: "h", Vendor: wfn.NA, Product: wfn.NA},
-				&wfn.Attributes{Part: "o", Vendor: wfn.NA, Product: wfn.NA},
-				&wfn.Attributes{Part: "a", Vendor: wfn.Any, Product: "geoip", Version: "1\\.5\\.0"},
+				{Part: "h", Vendor: wfn.NA, Product: wfn.NA},
+				{Part: "o", Vendor: wfn.NA, Product: wfn.NA},
+				{Part: "a", Vendor: wfn.Any, Product: "geoip", Version: "1\\.5\\.0"},
 			},
 			Dict: `
 		    <vuln:vulnerable-configuration id="http://nvd.nist.gov/">
@@ -138,7 +138,7 @@ func TestMatchXMLRequireVersion(t *testing.T) {
 </vuln:vulnerable-configuration>
 `
 	inventory := []*wfn.Attributes{
-		&wfn.Attributes{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
+		{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
 	}
 	var dict nvdxml.PlatformSpecificationType
 	if err := xml.Unmarshal([]byte(benchDict), &dict); err != nil {
@@ -164,8 +164,8 @@ func BenchmarkMatchXMLAny(b *testing.B) {
 </vuln:vulnerable-configuration>
 `
 	inventory := []*wfn.Attributes{
-		&wfn.Attributes{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
-		&wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
+		{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
+		{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
 	}
 	var dict nvdxml.PlatformSpecificationType
 	if err := xml.Unmarshal([]byte(benchDict), &dict); err != nil {
@@ -193,8 +193,8 @@ func BenchmarkMatchXMLExact(b *testing.B) {
 </vuln:vulnerable-configuration>
 `
 	inventory := []*wfn.Attributes{
-		&wfn.Attributes{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
-		&wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
+		{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
+		{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
 	}
 	var dict nvdxml.PlatformSpecificationType
 	if err := xml.Unmarshal([]byte(benchDict), &dict); err != nil {
@@ -222,8 +222,8 @@ func BenchmarkMatchXMLShortcuts(b *testing.B) {
 </vuln:vulnerable-configuration>
 `
 	inventory := []*wfn.Attributes{
-		&wfn.Attributes{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
-		&wfn.Attributes{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
+		{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
+		{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
 	}
 	var dict nvdxml.PlatformSpecificationType
 	if err := xml.Unmarshal([]byte(benchDict), &dict); err != nil {

--- a/wfn/wfn.go
+++ b/wfn/wfn.go
@@ -72,7 +72,7 @@ func Parse(s string) (*Attributes, error) {
 // This function isn't a part of standard. Quoted wildcards (*?) become unquoted ones (i.e. act as wildcards,
 // not a literal '*' and '?')
 // If wildcards are used, it is a responsibility of the user to make sure they comply with the standard, i.e.
-// only appear at the beggining or at the end of the string and, in case of asterisk, only once in each case.
+// only appear at the beginning or at the end of the string and, in case of asterisk, only once in each case.
 // Uppercase letters are valid avstring characters, but they are rarely (if ever) used in WFNs. It is recommended
 // to strings.ToLower() the string before passing it to this function.
 func WFNize(s string) (string, error) {


### PR DESCRIPTION
format with `gofmt -s`:
  * nvdtools/cmd/rpm2cpe/rpm2cpe_test.go
  * nvdtools/cmd/rpm2cpe/rpm2cpe_test.go
  * nvdtools/cvefeed/matching_xml_test.go

address linter warnings:

  * nvdtools/cmd/nvdsync/main.go
    * `Line 41: warning: don't use underscores in Go names; var default_ua should be defaultUa (golint)`

  * nvdtools/cmd/nvdsync/datafeed/http.go
    * `Line 25: warning: exported var UserAgent should have comment or be unexported (golint)`

spelling:

  * nvdtools/wfn/wfn.go:75: "beggining" is a misspelling of "beginning"
  * nvdtools/cmd/rpm2cpe/rpm2cpe_test.go:81: "succeded" is a misspelling of "succeeded"
  * nvdtools/cpedict/cpedict.go:113: "occurances" is a misspelling of "occurrences"
  * nvdtools/cpedict/lookup.go:52: "wich" is a misspelling of "which"