### PR TITLE
Adding versioning based on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ before_install:
 script: 
 - go get -v -u ./...
 - go test -v ./...
+
+before_deploy:
 - chmod +x build_tarballs.sh && ./build_tarballs.sh
 - make -C rpm/ 
 - dpkg-buildpackage -rfakeroot -uc -us && mv ../*.deb release

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CSV2CPE=csv2cpe
 NVDSYNC=nvdsync
 RPM2CPE=rpm2cpe
 
-VERSION=1.0
+VERSION=$(TRAVIS_TAG)
 NAME=nvdtools
 PKG=$(NAME)-$(VERSION)
 TGZ=$(PKG).tar.gz

--- a/build_tarballs.sh
+++ b/build_tarballs.sh
@@ -5,7 +5,7 @@ CSV2CPE=csv2cpe
 NVDSYNC=nvdsync
 RPM2CPE=rpm2cpe
 NAME=nvdtools
-VERSION=1.0
+VERSION=i$TRAVIS_TAG
 
 function build_binaries_and_tars(){
     GOOS=$1; shift


### PR DESCRIPTION
Since we want to dynamically create releases based on the git commit tags, we should reuse the tagging provided by travis.