### PR TITLE
Range matching for versions was performed wrong in nvdjson.MatchPlatform.

### DIFF
--- a/cvefeed/internal/nvdjson/smartvercmp_test.go
+++ b/cvefeed/internal/nvdjson/smartvercmp_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nvdjson
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSmartVerCmp(t *testing.T) {
+	cases := []struct {
+		v1, v2 string
+		ret    int
+	}{
+		{"1.0", "1.0", 0},
+		{"1.0.1", "1.0", 1},
+		{"1.0.14", "1.0.4", 1},
+		{"95SE", "98SP1", -1},
+		{"16.0.0", "3.2.7", 1},
+	}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%q vs %q", c.v1, c.v2), func(t *testing.T) {
+			if ret := smartVerCmp(c.v1, c.v2); ret != c.ret {
+				t.Fatalf("expected %d, got %d", ret, c.ret)
+			}
+		})
+	}
+}

--- a/cvefeed/matching_json_test.go
+++ b/cvefeed/matching_json_test.go
@@ -99,6 +99,19 @@ func TestMatchJSONrequireVersion(t *testing.T) {
 	}
 }
 
+func TestMatchJSONsmartVersionMatching(t *testing.T) {
+	inventory := []*wfn.Attributes{
+		{Part: "a", Vendor: "microsoft", Product: "ie", Version: "52\\.0"},
+	}
+	items, err := ParseJSON(bytes.NewBufferString(testJSONdict))
+	if err != nil {
+		t.Fatalf("failed to parse the dictionary: %v", err)
+	}
+	if _, ok := Match(inventory, items[1].Config(), true); ok {
+		t.Errorf("version %q unexpectedly matched", inventory[0].Version)
+	}
+}
+
 func BenchmarkMatchJSON(b *testing.B) {
 	inventory := []*wfn.Attributes{
 		{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},


### PR DESCRIPTION
It was compairing the version strings lexicographically, without any account of
versioning schemes (e.g. semver). Thus, version `16.0.0` was recognized as a smaller version than `3.0.0`:

```
dvl-mbp:cvefeed dvl$ go test -run smartVersion
--- FAIL: TestMatchJSONsmartVersionMatching (0.00s)
        matching_json_test.go:111: version 52\.0 matched, albeit it should not
FAIL
exit status 1
FAIL    github.com/facebookincubator/nvdtools/cvefeed   0.026s
```

This patch replaces relevant strings.Compare() calls with calls to a custom func smartVerCmp().
The latter splits the version on dots and processes each part separately.
It compares numerical suffixes at the beginning of each part as numbers and the rest lexicographically:
```
dvl-mbp:nvdjson dvl$ go test -v
=== RUN   TestSmartVerCmp
=== RUN   TestSmartVerCmp/"1.0"_vs_"1.0"
=== RUN   TestSmartVerCmp/"1.0.1"_vs_"1.0"
=== RUN   TestSmartVerCmp/"1.0.14"_vs_"1.0.4"
=== RUN   TestSmartVerCmp/"95SE"_vs_"98SP1"
=== RUN   TestSmartVerCmp/"16.0.0"_vs_"3.2.7"
--- PASS: TestSmartVerCmp (0.00s)
    --- PASS: TestSmartVerCmp/"1.0"_vs_"1.0" (0.00s)
    --- PASS: TestSmartVerCmp/"1.0.1"_vs_"1.0" (0.00s)
    --- PASS: TestSmartVerCmp/"1.0.14"_vs_"1.0.4" (0.00s)
    --- PASS: TestSmartVerCmp/"95SE"_vs_"98SP1" (0.00s)
    --- PASS: TestSmartVerCmp/"16.0.0"_vs_"3.2.7" (0.00s)
PASS
ok      github.com/facebookincubator/nvdtools/cvefeed/internal/nvdjson  0.023s
```

This is the most universally correct behaviour I can think of currently:
```
dvl-mbp:cvefeed dvl$ go test -run smartVer
PASS
ok      github.com/facebookincubator/nvdtools/cvefeed   0.026s
dvl-mbp:cvefeed dvl$ go test -v -run smartVer
=== RUN   TestMatchJSONsmartVersionMatching
--- PASS: TestMatchJSONsmartVersionMatching (0.00s)
PASS
ok      github.com/facebookincubator/nvdtools/cvefeed   0.025s
```

This is in no way an ideal solution, the performance is terrible and most certanly, not all cases are covered,
but we need it fast.