### PR TITLE
Fixing versioning of releases to get rid of `v` in files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
 - go test -v ./...
 
 before_deploy:
+- export VERSION=${TRAVIS_TAG:1}
 - chmod +x build_tarballs.sh && ./build_tarballs.sh
 - make -C rpm/
 - dpkg-buildpackage -rfakeroot -uc -us && mv ../*.deb release

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ CSV2CPE=csv2cpe
 NVDSYNC=nvdsync
 RPM2CPE=rpm2cpe
 
-VERSION=$(TRAVIS_TAG)
 NAME=nvdtools
 PKG=$(NAME)-$(VERSION)
 TGZ=$(PKG).tar.gz

--- a/build_tarballs.sh
+++ b/build_tarballs.sh
@@ -5,7 +5,6 @@ CSV2CPE=csv2cpe
 NVDSYNC=nvdsync
 RPM2CPE=rpm2cpe
 NAME=nvdtools
-VERSION=$TRAVIS_TAG
 
 function build_binaries_and_tars(){
     GOOS=$1; shift

--- a/build_tarballs.sh
+++ b/build_tarballs.sh
@@ -11,10 +11,11 @@ function build_binaries_and_tars(){
     ARCHS=("$@")
     for GOARCH in ${ARCHS[@]}; do
         for BINARY in $CPE2CVE $CSV2CPE $NVDSYNC $RPM2CPE; do
-            env GOOS=$GOOS GOARCH=$GOARCH go build -o binaries/$BINARY-$VERSION-$GOOS-$GOARCH ./cmd/$BINARY
+            env GOOS=$GOOS GOARCH=$GOARCH go build -o $BINARY ./cmd/$BINARY
         done
 	tar -zcvf release/$NAME-$VERSION-$GOOS-$GOARCH.tar.gz \
-            binaries/{$CPE2CVE,$CSV2CPE,$NVDSYNC,$RPM2CPE}-$VERSION-$GOOS-$GOARCH
+            {$CPE2CVE,$CSV2CPE,$NVDSYNC,$RPM2CPE}
+	make clean
     done
 }
 

--- a/debian/rules
+++ b/debian/rules
@@ -2,3 +2,7 @@
 
 %:
 	dh $@  
+
+override_dh_gencontrol:
+	dh_gencontrol -- -v$(VERSION)
+

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -8,4 +8,4 @@ all:
 	mv ../nvdtools-*.gz $(HOME)/rpmbuild/SOURCES
 	cp nvdtools.spec $(HOME)/rpmbuild/SPECS
 	cd $(HOME)/rpmbuild/SPECS
-	rpmbuild -ba --define="_tag $(TRAVIS_TAG)" nvdtools.spec
+	rpmbuild -ba --define="_tag $(VERSION)" nvdtools.spec


### PR DESCRIPTION
Current releases had `v` in all the files which is against a current standard.
Therefore, we should remove this.

Example versioning: ![image](https://user-images.githubusercontent.com/17247404/51634663-bcfa3300-1f4c-11e9-90c6-eba5f666c8cc.png)
