### PR TITLE
Improve the performance of smartVerCmp function.

### DIFF
--- a/cvefeed/internal/nvdjson/smartvercmp_test.go
+++ b/cvefeed/internal/nvdjson/smartvercmp_test.go
@@ -39,3 +39,22 @@ func TestSmartVerCmp(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkSmartVerCmp(b *testing.B) {
+	cases := []struct {
+		v1, v2 string
+	}{
+		{"1.0", "1.0"},
+		{"1.0.1", "1.0"},
+		{"1.0.14", "1.0.4"},
+		{"95SE", "98SP1"},
+		{"16.0.0", "3.2.7"},
+		{"10.23", "10.21"},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, c := range cases {
+			smartVerCmp(c.v1, c.v2)
+		}
+	}
+}


### PR DESCRIPTION
I figured, there was no need to actually parse the numbers from the strings. These are integers with no leading zeros, hence the longer one is the larger and if the length is equal, then lexicographical comparison does the right thing.

Benchmarks (BenchmarkSmartVerCmp is the new version and BenchmarkSmartVerCmp2 is the old one):

```
$ go test -bench .
goos: linux
goarch: amd64
pkg: github.com/facebookincubator/nvdtools/cvefeed/internal/nvdjson
BenchmarkSmartVerCmp-8          20000000                99.9 ns/op
BenchmarkSmartVerCmp2-8         10000000               206 ns/op
PASS
```