### PR TITLE
[cmd/cpe2cve] Introduce feeds overrides.

### DIFF
--- a/cmd/cpe2cve/cpe2cve_test.go
+++ b/cmd/cpe2cve/cpe2cve_test.go
@@ -70,12 +70,16 @@ func TestProcessInput(t *testing.T) {
 		},
 		// TODO: add more test cases
 	}
-	testDictXML, err := cvefeed.ParseXML(strings.NewReader(testDictXMLStr))
+	testDictXML, err := cvefeed.LoadFeed(func(_ string) ([]cvefeed.CVEItem, error) {
+		return cvefeed.ParseXML(bytes.NewBufferString(testDictXMLStr))
+	}, "")
 	if err != nil {
 		t.Fatalf("couldn't parse XML dictionary: %v", err)
 	}
 	cacheXML := cvefeed.NewCache(testDictXML)
-	testDictJSON, err := cvefeed.ParseJSON(strings.NewReader(testDictJSONStr))
+	testDictJSON, err := cvefeed.LoadFeed(func(_ string) ([]cvefeed.CVEItem, error) {
+		return cvefeed.ParseJSON(bytes.NewBufferString(testDictJSONStr))
+	}, "")
 	if err != nil {
 		t.Fatalf("couldn't parse JSON dictionary: %v", err)
 	}
@@ -124,7 +128,9 @@ func TestProcessInput(t *testing.T) {
 // This used to cause false postives, added this test during the debug session
 func TestProcessInputFalsePositives(t *testing.T) {
 	in := "cpe:/a::glibc:2.27-1"
-	dict, err := cvefeed.ParseJSON(strings.NewReader(testDictJSONStr2))
+	dict, err := cvefeed.LoadFeed(func(_ string) ([]cvefeed.CVEItem, error) {
+		return cvefeed.ParseJSON(bytes.NewBufferString(testDictJSONStr2))
+	}, "")
 	if err != nil {
 		t.Fatalf("couldn't parse JSON dictionary: %v", err)
 	}
@@ -151,7 +157,9 @@ func TestProcessInputFalsePositives(t *testing.T) {
 
 func TestProcessInputRequireVersion(t *testing.T) {
 	in := "cpe:/h:huaweidevice:d100:1.33.7"
-	dict, err := cvefeed.ParseJSON(strings.NewReader(testDictJSONStr2))
+	dict, err := cvefeed.LoadFeed(func(_ string) ([]cvefeed.CVEItem, error) {
+		return cvefeed.ParseJSON(bytes.NewBufferString(testDictJSONStr2))
+	}, "")
 	if err != nil {
 		t.Fatalf("couldn't parse JSON dictionary: %v", err)
 	}
@@ -182,7 +190,9 @@ func BenchmarkProcessInputXML(t *testing.B) {
 1;2;3;cpe:/o::centos_linux:7.5.1804,cpe:/a::chardet:2.2.1,cpe:/a::javapackages:1.0.0,cpe:/a::kitchen:1.1.1,cpe:/a::nose:1.3.7,cpe:/a::python-dateutil:1.5,cpe:/a::pytz:2016.10,cpe:/a::setuptools:0.9.8,cpe:/a::chardet:2.2.1,cpe:/a::javapackages:1.0.0,cpe:/a::kitchen:1.1.1,cpe:/a::nose:1.3.7,cpe:/a::python-dateutil:1.5,cpe:/a::pytz:2016.10,cpe:/a::setuptools:0.9.8
 1;2;3;cpe:/o::centos_linux:7.5.1804,cpe:/a::chardet:2.2.1,cpe:/a::kitchen:1.1.1,cpe:/a::chardet:2.2.1,cpe:/a::kitchen:1.1.1,cpe:/a::chardet:2.2.1,cpe:/a::kitchen:1.1.1
 `
-	testDict, err := cvefeed.ParseXML(strings.NewReader(testDictXMLStr))
+	testDict, err := cvefeed.LoadFeed(func(_ string) ([]cvefeed.CVEItem, error) {
+		return cvefeed.ParseXML(bytes.NewBufferString(testDictXMLStr))
+	}, "")
 	if err != nil {
 		t.Fatalf("couldn't parse dictionary: %v", err)
 	}
@@ -213,7 +223,9 @@ func BenchmarkProcessInputJSON(t *testing.B) {
 1;2;3;cpe:/o::centos_linux:7.5.1804,cpe:/a::chardet:2.2.1,cpe:/a::javapackages:1.0.0,cpe:/a::kitchen:1.1.1,cpe:/a::nose:1.3.7,cpe:/a::python-dateutil:1.5,cpe:/a::pytz:2016.10,cpe:/a::setuptools:0.9.8,cpe:/a::chardet:2.2.1,cpe:/a::javapackages:1.0.0,cpe:/a::kitchen:1.1.1,cpe:/a::nose:1.3.7,cpe:/a::python-dateutil:1.5,cpe:/a::pytz:2016.10,cpe:/a::setuptools:0.9.8
 1;2;3;cpe:/o::centos_linux:7.5.1804,cpe:/a::chardet:2.2.1,cpe:/a::kitchen:1.1.1,cpe:/a::chardet:2.2.1,cpe:/a::kitchen:1.1.1,cpe:/a::chardet:2.2.1,cpe:/a::kitchen:1.1.1
 `
-	testDict, err := cvefeed.ParseJSON(strings.NewReader(testDictJSONStr))
+	testDict, err := cvefeed.LoadFeed(func(_ string) ([]cvefeed.CVEItem, error) {
+		return cvefeed.ParseJSON(bytes.NewBufferString(testDictJSONStr))
+	}, "")
 	if err != nil {
 		t.Fatalf("couldn't parse dictionary: %v", err)
 	}

--- a/cmd/cpe2cve/fieldstoskip.go
+++ b/cmd/cpe2cve/fieldstoskip.go
@@ -1,0 +1,138 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// filedsToSkip is a custom type to be recognized by flag.Parse().
+// It maps comma-separated numbers from command line option to a set of integers.
+// It also provides methods for dropping configured indices from a slice.
+type fieldsToSkip map[int]struct{}
+
+// skipFields removes elements from  fields slice as per config
+func (fs fieldsToSkip) skipFields(fields []string) []string {
+	j := 0
+	for i := 0; i < len(fields); i++ {
+		if _, ok := fs[i]; ok {
+			continue
+		}
+		fields[j] = fields[i]
+		j++
+	}
+	return fields[:j]
+}
+
+// appendAt appends and element to a slice at position at after skipping configured fields
+func (fs fieldsToSkip) appendAt(to []string, args ...interface{}) []string {
+	to = fs.skipFields(to)
+	fields := map[int]string{}
+	keys := make([]int, 0, len(args)/2)
+	pos := -1
+	for _, arg := range args {
+		switch arg.(type) {
+		case int:
+			pos = arg.(int)
+			keys = append(keys, pos)
+		case string:
+			if pos == -1 {
+				panic("appendAt: string field was not prepended by position")
+			}
+			fields[pos] = arg.(string)
+			pos = -1
+		default:
+			panic(fmt.Sprintf("appendAt: unsupported type %T", arg))
+		}
+	}
+	sort.Ints(keys)
+	for _, at := range keys {
+		if at > len(to) {
+			at = len(to)
+		}
+		out := make([]string, 0, len(to)+1)
+		out = append(out, to[:at]...)
+		out = append(out, fields[at])
+		out = append(out, to[at:]...)
+		to = out
+	}
+	return to
+}
+
+// part of flag.Value interface implementation
+func (fs fieldsToSkip) String() string {
+	keys := make([]int, 0, len(fs))
+	for k := range fs {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	fss := make([]string, len(keys))
+	for i, v := range keys {
+		fss[i] = fmt.Sprintf("%d", v+1)
+	}
+	return strings.Join(fss, ",")
+}
+
+// part of flag.Value interface implementation
+func (fs *fieldsToSkip) Set(val string) error {
+	if *fs == nil {
+		*fs = fieldsToSkip{}
+	}
+	for _, v := range strings.Split(val, ",") {
+		nn, err := atoii(v)
+		if err != nil {
+			return fmt.Errorf("bad fieldsToSkip value: %q: %v", v, err)
+		}
+		for _, n := range nn {
+			if n < 1 {
+				return fmt.Errorf("illegal field index %d", n)
+			}
+			(*fs)[n-1] = struct{}{}
+		}
+	}
+	return nil
+}
+
+// atoii parses ranges of positive integers from string r.
+// E.g., it will return [1, 2, 3, 4] for "1-4", [3] for "3";
+// Open ranges (e.g. "-3", "3-") are not allowed and are parsed as a single integer.
+// Any character other than digit or '-' in the input will trigger an error.
+func atoii(r string) ([]int, error) {
+	var ret []int
+	fromto := strings.Split(r, "-")
+	if len(fromto) != 1 && len(fromto) != 2 {
+		return nil, fmt.Errorf("illegal range: %q", r)
+	}
+	start, err := strconv.Atoi(fromto[0])
+	if err != nil {
+		return nil, err
+	}
+	ret = append(ret, start)
+	if len(fromto) == 1 {
+		return ret, nil
+	}
+	end, err := strconv.Atoi(fromto[1])
+	if err != nil {
+		return nil, err
+	}
+	for i := start + 1; i < end; i++ {
+		ret = append(ret, i)
+	}
+	ret = append(ret, end)
+	return ret, nil
+}

--- a/cmd/cpe2cve/fieldstoskip_test.go
+++ b/cmd/cpe2cve/fieldstoskip_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFieldsToSkip(t *testing.T) {
+	cases := []struct {
+		in, out string
+		fail    bool
+	}{
+		{"", "", true},
+		{"foo", "", true},
+		{"1", "1", false},
+		{"1,2,3", "1,2,3", false},
+		{"3-5", "3,4,5", false},
+	}
+	for n, c := range cases {
+		c := c
+		t.Run(fmt.Sprintf("%d", n+1), func(t *testing.T) {
+			var f2s fieldsToSkip
+			err := f2s.Set(c.in)
+			if err != nil && !c.fail {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			out := f2s.String()
+			if out != c.out {
+				t.Fatalf("expected %q, got %q", c.out, out)
+			}
+		})
+	}
+}

--- a/cmd/cpe2cve/multistring.go
+++ b/cmd/cpe2cve/multistring.go
@@ -1,0 +1,34 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+)
+
+// multiString is a custom type to be recognized by flag.Parse().
+// It maps multiple occurances of the flag into slice of strings.
+type multiString []string
+
+// part of flag.Value interface implementation
+func (ms *multiString) String() string {
+	return fmt.Sprintf("%v", *ms)
+}
+
+// part of flag.Value interface implementation
+func (ms *multiString) Set(val string) error {
+	*ms = append(*ms, val)
+	return nil
+}

--- a/cvefeed/cvecache.go
+++ b/cvefeed/cvecache.go
@@ -209,7 +209,7 @@ func (c *Cache) dictFromIndex(cpes []*wfn.Attributes) Dictionary {
 				continue
 			}
 			knownEntries[e] = true
-			d = append(d, e)
+			d[e.CVEID()] = e
 		}
 	}
 	for _, e := range c.Idx[wfn.Any] {
@@ -217,7 +217,7 @@ func (c *Cache) dictFromIndex(cpes []*wfn.Attributes) Dictionary {
 			continue
 		}
 		knownEntries[e] = true
-		d = append(d, e)
+		d[e.CVEID()] = e
 	}
 	return d
 }

--- a/cvefeed/eviction_test.go
+++ b/cvefeed/eviction_test.go
@@ -23,7 +23,9 @@ import (
 )
 
 func TestCacheEviction(t *testing.T) {
-	items, err := ParseJSON(bytes.NewBufferString(testJSONdict))
+	items, err := LoadFeed(func(_ string) ([]CVEItem, error) {
+		return ParseJSON(bytes.NewBufferString(testJSONdict))
+	}, "")
 	if err != nil {
 		t.Fatalf("failed to parse the dictionary: %v", err)
 	}
@@ -44,7 +46,7 @@ func TestCacheEviction(t *testing.T) {
 			}
 			matches := cache.Get(inventory)
 			if len(matches) != 1 {
-				t.Errorf("variant %d: cache.Get() returned wrong amount of matches (%d, 1 was expected)", variant, len(matches))
+				t.Fatalf("variant %d: cache.Get() returned wrong amount of matches (%d, 1 was expected)", variant, len(matches))
 			}
 			if len(matches[0].CPEs) != 1 {
 				t.Errorf("variant %d: cache.Get() returned wrong a match with wrong number of CPEs (%d, 1 was expected)", variant, len(matches[0].CPEs))
@@ -71,7 +73,7 @@ func TestCacheEviction(t *testing.T) {
 		}
 		matches := cache.Get(inventory)
 		if len(matches) != 1 {
-			t.Errorf("variant %d: cache.Get() returned wrong amount of matches (%d, 1 was expected)", variant, len(matches))
+			t.Fatalf("variant %d: cache.Get() returned wrong amount of matches (%d, 1 was expected)", variant, len(matches))
 		}
 		if len(matches[0].CPEs) != 1 {
 			t.Errorf("variant %d: cache.Get() returned wrong a match with wrong number of CPEs (%d, 1 was expected)", variant, len(matches[0].CPEs))

--- a/cvefeed/internal/iface/iface.go
+++ b/cvefeed/internal/iface/iface.go
@@ -33,3 +33,71 @@ type CVEItem interface {
 	CVEID() string
 	Config() []LogicalTest
 }
+
+// MergeCVEItems combines two CVEItems:
+// resulted CVEItem inherits all mutually exclusive methods (e.g. CVEID()) from CVEItem x;
+// but Configuration() call returns rule equal to x.LogicalTests AND NOT y.LogicalTests
+func MergeCVEItems(x, y CVEItem) CVEItem {
+	xOp := mergeOperator{
+		inners: x.Config(),
+	}
+	yOp := mergeOperator{
+		negate: true,
+		inners: y.Config(),
+	}
+	mergeOp := mergeOperator{
+		override: true,
+		inners:   []LogicalTest{&xOp, &yOp},
+	}
+
+	z := mergeCVEItem{
+		id:     x.CVEID(),
+		config: []LogicalTest{mergeOp},
+	}
+
+	return z
+}
+
+type mergeCVEItem struct {
+	id     string
+	config []LogicalTest
+}
+
+func (i mergeCVEItem) CVEID() string {
+	return i.id
+}
+
+func (i mergeCVEItem) Config() []LogicalTest {
+	return i.config
+}
+
+type mergeOperator struct {
+	override, negate bool
+	inners           []LogicalTest
+}
+
+func (mo mergeOperator) LogicalOperator() string {
+	if mo.override {
+		return "and"
+	}
+	return "or"
+}
+
+func (mo mergeOperator) NegateIfNeeded(b bool) bool {
+	if mo.negate {
+		return !b
+	}
+	return b
+}
+
+func (mo mergeOperator) InnerTests() []LogicalTest {
+	return mo.inners
+}
+
+func (mo mergeOperator) MatchPlatform(_ *wfn.Attributes, _ bool) bool {
+	return false
+}
+
+func (mo mergeOperator) CPEs() []*wfn.Attributes {
+	return nil
+}

--- a/cvefeed/matching_overrides_test.go
+++ b/cvefeed/matching_overrides_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cvefeed
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/facebookincubator/nvdtools/wfn"
+)
+
+func TestMatchOverrides(t *testing.T) {
+	cases := [][]*wfn.Attributes{
+		[]*wfn.Attributes{},
+		[]*wfn.Attributes{
+			{Part: "o", Vendor: "linux", Product: "linux_kernel", Version: "2\\.6\\.1"},
+			{Part: "a", Vendor: "djvulibre_project", Product: "djvulibre", Version: "3\\.5\\.11"},
+		},
+		[]*wfn.Attributes{
+			{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
+			{Part: "a", Vendor: "microsoft", Product: "ie", Version: "5\\.0", Update: wfn.NA},
+		},
+		[]*wfn.Attributes{
+			{Part: "o", Vendor: "microsoft", Product: "windows_xp", Update: "sp3"},
+			{Part: "a", Vendor: "microsoft", Product: "ie", Version: "5\\.0", Update: "patched"},
+		},
+	}
+	dict, err := LoadFeed(func(_ string) ([]CVEItem, error) {
+		return ParseJSON(bytes.NewBufferString(testJSONdict))
+	}, "")
+	if err != nil {
+		t.Fatalf("could not load test JSON feed: %v", err)
+	}
+	original, _ := LoadFeed(func(_ string) ([]CVEItem, error) {
+		return ParseJSON(bytes.NewBufferString(testJSONdict))
+	}, "")
+	overrides, err := LoadFeed(func(_ string) ([]CVEItem, error) {
+		return ParseJSON(bytes.NewBufferString(testJSONoverride))
+	}, "")
+	if err != nil {
+		t.Fatalf("could not load test overrides: %v", err)
+	}
+	dict.Override(overrides)
+	for n, c := range cases {
+		c := c
+		t.Run(fmt.Sprintf("%d", n), func(t *testing.T) {
+			var matchOriginal, matchOverride, matchDict bool
+			if _, m := Match(c, dict["TESTVE-2018-0002"].Config(), false); m {
+				matchDict = true
+			}
+			if _, m := Match(c, original["TESTVE-2018-0002"].Config(), false); m {
+				matchOriginal = true
+			}
+			if _, m := Match(c, overrides["TESTVE-2018-0002"].Config(), false); m {
+				matchOverride = true
+			}
+			if matchOriginal && matchDict && matchOverride {
+				t.Fatal("case was not overriden")
+			} else if matchDict && !matchOriginal {
+				t.Fatal("unexpected match")
+			}
+		})
+	}
+}
+
+var testJSONoverride = `{
+"CVE_data_type" : "CVE",
+"CVE_data_format" : "MITRE",
+"CVE_data_version" : "4.0",
+"CVE_data_numberOfCVEs" : "7083",
+"CVE_data_timestamp" : "2018-07-31T07:00Z",
+"CVE_Items" : [
+  {
+    "cve" : {
+      "data_type" : "CVE",
+      "data_format" : "MITRE",
+      "data_version" : "4.0",
+      "CVE_data_meta" : {
+        "ID" : "TESTVE-2018-0002",
+        "ASSIGNER" : "cve@mitre.org"
+      }
+    },
+    "configurations" : {
+      "CVE_data_version" : "4.0",
+      "nodes" : [
+        {
+          "operator" : "OR",
+          "cpe_match" : [ {
+            "vulnerable" : true,
+              "cpe23Uri" : "cpe:2.3:a:microsoft:ie:*:patched:*:*:*:*:*:*"
+          } ]
+        }
+      ]
+    }
+  }
+]
+}`


### PR DESCRIPTION
E.g.:
```
cat ./inventory.csv | cpe2cve -feed json -cpe 1 -cve 2 -r ./override1.json -r ./override2.json ./feed.json
```

This resolves #9.

As a collateral damage this also resolves #23 (I was bored, I guess).