### PR TITLE
Fix smartVerCmp (again).

### DIFF
--- a/cvefeed/internal/nvdjson/interfaces.go
+++ b/cvefeed/internal/nvdjson/interfaces.go
@@ -176,7 +176,7 @@ func smartVerCmp(v1, v2 string) int {
 // E.g. parseVerParts("11b.4.16-New_Year_Edition") will return (2, 4)
 func parseVerParts(v string) (num, skip int) {
 	for skip = 0; skip < len(v); skip++ {
-		if v[skip] < 0 || v[skip] > '9' {
+		if v[skip] < '0' || v[skip] > '9' {
 			break
 		}
 	}

--- a/cvefeed/internal/nvdjson/smartvercmp_test.go
+++ b/cvefeed/internal/nvdjson/smartvercmp_test.go
@@ -30,6 +30,7 @@ func TestSmartVerCmp(t *testing.T) {
 		{"95SE", "98SP1", -1},
 		{"16.0.0", "3.2.7", 1},
 		{"10.23", "10.21", 1},
+		{"64.0", "3.6.24", 1},
 	}
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%q vs %q", c.v1, c.v2), func(t *testing.T) {

--- a/cvefeed/matching_json_test.go
+++ b/cvefeed/matching_json_test.go
@@ -68,6 +68,13 @@ func TestMatchJSON(t *testing.T) {
 			},
 			Expect: true,
 		},
+		{
+			Rule: 2,
+			Inventory: []*wfn.Attributes{
+				{Part: "a", Vendor: "mozilla", Product: "firefox", Version: "64\\.0"},
+			},
+			Expect: false,
+		},
 	}
 	items, err := ParseJSON(bytes.NewBufferString(testJSONdict))
 	if err != nil {
@@ -204,6 +211,31 @@ var testJSONdict = `{
         }
       ]
     }
+  },
+	{
+    "cve": {
+      "data_format": "MITRE",
+      "data_type": "CVE",
+      "data_version": "4.0",
+      "CVE_data_meta": {
+        "ASSIGNER": "cve@mitre.org",
+        "ID": "CVE-2002-2436"
+      }
+    },
+    "configurations": {
+      "CVE_data_version": "4.0",
+      "nodes": [
+        {
+          "cpe_match": [
+            {
+              "cpe23Uri": "cpe:2.3:a:mozilla:firefox:*:*:*:*:*:*:*:*",
+              "versionEndIncluding": "3.6.24",
+              "vulnerable": true
+            }
+          ],
+          "operator": "OR"
+        }
+      ]
+    }
   }
-]
-}`
+] }`


### PR DESCRIPTION
The check for character being a digit was broken. Everything boils down to this:

```
-               if v[skip] < 0 || v[skip] > '9' {
+               if v[skip] < '0' || v[skip] > '9' {
```