### PR TITLE
[cpe2cve] new feature: output CVSS base score and CWE.

### DIFF
--- a/cmd/cpe2cve/fieldstoskip.go
+++ b/cmd/cpe2cve/fieldstoskip.go
@@ -39,7 +39,8 @@ func (fs fieldsToSkip) skipFields(fields []string) []string {
 	return fields[:j]
 }
 
-// appendAt appends and element to a slice at position at after skipping configured fields
+// appendAt appends and element to a slice at position at after skipping configured fields.
+// Negative pos skips the next element.
 func (fs fieldsToSkip) appendAt(to []string, args ...interface{}) []string {
 	to = fs.skipFields(to)
 	fields := map[int]string{}
@@ -49,10 +50,12 @@ func (fs fieldsToSkip) appendAt(to []string, args ...interface{}) []string {
 		switch arg.(type) {
 		case int:
 			pos = arg.(int)
-			keys = append(keys, pos)
+			if pos >= 0 {
+				keys = append(keys, pos)
+			}
 		case string:
-			if pos == -1 {
-				panic("appendAt: string field was not prepended by position")
+			if pos < 0 {
+				break
 			}
 			fields[pos] = arg.(string)
 			pos = -1

--- a/cvefeed/cvecache.go
+++ b/cvefeed/cvecache.go
@@ -68,7 +68,7 @@ func collectCPEs(dict []LogicalTest) (cpes []*wfn.Attributes) {
 
 // MatchResult stores CVE and a slice of CPEs that matched it
 type MatchResult struct {
-	CVE  string
+	CVE  CVEItem
 	CPEs []*wfn.Attributes
 }
 
@@ -88,7 +88,7 @@ func (cves *cachedCVEs) updateResSize(key string) {
 	}
 	cves.size += int(unsafe.Sizeof(cves.res))
 	for i := range cves.res {
-		cves.size += int(unsafe.Sizeof(cves.res[i].CVE)) + len(cves.res[i].CVE)
+		cves.size += int(unsafe.Sizeof(cves.res[i].CVE))
 		for _, attr := range cves.res[i].CPEs {
 			cves.size += len(attr.Part) + int(unsafe.Sizeof(attr.Part))
 			cves.size += len(attr.Vendor) + int(unsafe.Sizeof(attr.Vendor))
@@ -229,7 +229,7 @@ func (c *Cache) match(cpes []*wfn.Attributes, dict Dictionary) (result []MatchRe
 	for _, v := range dict {
 		if mm, ok := Match(cpes, v.Config(), c.RequireVersion); ok {
 			mm = uniq(mm)
-			result = append(result, MatchResult{v.CVEID(), mm})
+			result = append(result, MatchResult{v, mm})
 		}
 	}
 	return result

--- a/cvefeed/eviction_test.go
+++ b/cvefeed/eviction_test.go
@@ -34,8 +34,8 @@ func TestCacheEviction(t *testing.T) {
 
 	// first, run concurrently and enjoy different sizes of cache logged on each run
 	var wg sync.WaitGroup
-	wg.Add(40)
-	for i := 0; i < 40; i++ {
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
 		go func(variant int) {
 			defer wg.Done()
 			inventory := []*wfn.Attributes{
@@ -63,7 +63,7 @@ func TestCacheEviction(t *testing.T) {
 	t.Logf("concurrent run: cache size %d/%d; %d records cached", cache.size, cache.MaxSize, len(cache.data))
 
 	// now let's get serious and get some deterministic resutls
-	for i := 0; i < 40; i++ {
+	for i := 0; i < 50; i++ {
 		variant := i
 		inventory := []*wfn.Attributes{
 			matchingItem,

--- a/cvefeed/internal/nvdxml/interfaces.go
+++ b/cvefeed/internal/nvdxml/interfaces.go
@@ -19,14 +19,30 @@ import (
 	"github.com/facebookincubator/nvdtools/wfn"
 )
 
-// CVEID implements part of cvefeed.CVEItem interface
+// CVEID returns the identifier of the vulnerability (e.g. CVE).
 func (e *Entry) CVEID() string {
 	return e.ID
 }
 
-// Config implemens part of cvefeed.CVEItem interface
+// Config returns a set of tests that identify vulnerable platform.
 func (e *Entry) Config() []iface.LogicalTest {
 	return e.ifaceConfig
+}
+
+// ProblemTypes returns weakness types associated with vulnerability (e.g. CWE)
+func (e *Entry) ProblemTypes() []string {
+	return nil
+}
+
+// CVSS20base returns CVSS 2.0 base score of vulnerability
+func (e *Entry) CVSS20base() float64 {
+	return e.CVSSscore
+}
+
+// CVSS30base returns CVSS 3.0 base score of vulnerability
+func (e *Entry) CVSS30base() float64 {
+	// XML feed only reports CVSS20
+	return 0.0
 }
 
 // PlatformSpecificationType is a cvefeed.LogicalTest

--- a/cvefeed/internal/nvdxml/schema.go
+++ b/cvefeed/internal/nvdxml/schema.go
@@ -135,12 +135,19 @@ type PlatformSpecificationType struct {
 	// CheckFactRef          *CheckFactRefType `xml:"check-fact-ref"`
 }
 
+// CWEType represents CWE
+type CWEType struct {
+	CWE string `xml:"id,attr"`
+}
+
 // Entry represents a CVE entry
 type Entry struct {
 	ID            string                       `xml:"id,attr"`
 	Configuration []*PlatformSpecificationType `xml:"vulnerable-configuration"`
 	ifaceConfig   []iface.LogicalTest          // for reparsing Config field as []iface.LogicalTest
 	CVE           string                       `xml:"cve-id"`
+	CWEs          []*CWEType                   `xml:"cwe"`
+	CVSSscore     float64                      `xml:"cvss>base_metrics>score"`
 }
 
 // NVDFeed represents the root element of NVD CVE feed


### PR DESCRIPTION
CVSS base score and CWE allow us to evaluate the severity of vulnerabilities we find.
Ideally cpe2cve should be able to output any information about vulnerability, granted that informatino is in the feed.
That's a start, we can add more later.
This solves #24.

SOZ, no unittests, #movefast:

```
$ echo cpe:/o:juniper:junos:12.1x46 | ./cpe2cve -cpe 1 -cve 2 -cwe 3 -cvss 4 -cvss2 5 -cvss3 6 ~/feeds/xml/nvdcve-2.0-2018.xml.gz
cpe:/o:juniper:junos:12.1x46    CVE-2018-0019           4.3     4.3     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0001           7.5     7.5     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0017           6.8     6.8     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0031           4.3     4.3     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0003           6.1     6.1     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0007           10.0    10.0    0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0052           9.3     9.3     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0004           7.1     7.1     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0022           7.8     7.8     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0051           4.3     4.3     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0061           5.0     5.0     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0049           7.1     7.1     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0062           5.0     5.0     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0060           4.3     4.3     0.0
```

```
$ echo cpe:/o:juniper:junos:12.1x46 | ./cpe2cve -feed json -cpe 1 -cve 2 -cwe 3 -cvss 4 -cvss2 5 -cvss3 6 ~/feeds/json/nvdcve-1.0-2018.json.gz
cpe:/o:juniper:junos:12.1x46    CVE-2018-0003   CWE-399 6.5     6.1     6.5
cpe:/o:juniper:junos:12.1x46    CVE-2018-0062   CWE-20  7.5     5.0     7.5
cpe:/o:juniper:junos:12.1x46    CVE-2018-0019   CWE-20  5.9     4.3     5.9
cpe:/o:juniper:junos:12.1x46    CVE-2018-0051   CWE-20  5.9     4.3     5.9
cpe:/o:juniper:junos:12.1x46    CVE-2018-0061   CWE-400 5.3     5.0     5.3
cpe:/o:juniper:junos:12.1x46    CVE-2018-0004   CWE-400 6.5     7.1     6.5
cpe:/o:juniper:junos:12.1x46    CVE-2018-0060   CWE-20  5.9     4.3     5.9
cpe:/o:juniper:junos:12.1x46    CVE-2018-0031   CWE-400 5.9     4.3     5.9
cpe:/o:juniper:junos:12.1x46    CVE-2018-0017   CWE-20  6.5     6.8     6.5
cpe:/o:juniper:junos:12.1x46    CVE-2018-0052   CWE-287 8.1     9.3     8.1
cpe:/o:juniper:junos:12.1x46    CVE-2018-0049   CWE-476 5.9     7.1     5.9
cpe:/o:juniper:junos:12.1x46    CVE-2018-0007   CWE-94  9.8     10.0    9.8
cpe:/o:juniper:junos:12.1x46    CVE-2018-0022   CWE-400 7.5     7.8     7.5
cpe:/o:juniper:junos:12.1x46    CVE-2018-0001   CWE-416 9.8     7.5     9.8
```

```
$ go test ./...
ok      github.com/facebookincubator/nvdtools/cmd/cpe2cve       (cached)
ok      github.com/facebookincubator/nvdtools/cmd/csv2cpe       (cached)
?       github.com/facebookincubator/nvdtools/cmd/nvdsync       [no test files]
ok      github.com/facebookincubator/nvdtools/cmd/nvdsync/datafeed      (cached)
ok      github.com/facebookincubator/nvdtools/cmd/rpm2cpe       (cached)
ok      github.com/facebookincubator/nvdtools/cpedict   (cached)
ok      github.com/facebookincubator/nvdtools/cpeparse  (cached)
ok      github.com/facebookincubator/nvdtools/cvefeed   0.048s
?       github.com/facebookincubator/nvdtools/cvefeed/internal/iface    [no test files]
ok      github.com/facebookincubator/nvdtools/cvefeed/internal/nvdjson  (cached)
?       github.com/facebookincubator/nvdtools/cvefeed/internal/nvdxml   [no test files]
ok      github.com/facebookincubator/nvdtools/wfn       (cached)
```