### PR TITLE
[cpe2cve] forgot to implement CVEItem.ProblemTypes() func for XML feed

### DIFF
--- a/cvefeed/internal/nvdxml/interfaces.go
+++ b/cvefeed/internal/nvdxml/interfaces.go
@@ -31,7 +31,11 @@ func (e *Entry) Config() []iface.LogicalTest {
 
 // ProblemTypes returns weakness types associated with vulnerability (e.g. CWE)
 func (e *Entry) ProblemTypes() []string {
-	return nil
+	var cwes []string
+	for _, cwe := range e.CWEs {
+		cwes = append(cwes, cwe.CWE)
+	}
+	return cwes
 }
 
 // CVSS20base returns CVSS 2.0 base score of vulnerability


### PR DESCRIPTION
 :[

```
$ echo cpe:/o:juniper:junos:12.1x46 | ./cpe2cve -cpe 1 -cve 2 -cwe 3 -cvss 4 -cvss2 5 -cvss3 6 ~/feeds/xml/nvdcve-2.0-2018.xml.gz
cpe:/o:juniper:junos:12.1x46    CVE-2018-0004   CWE-400 7.1     7.1     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0019   CWE-20  4.3     4.3     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0051   CWE-20  4.3     4.3     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0049   CWE-476 7.1     7.1     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0060   CWE-20  4.3     4.3     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0017   CWE-20  6.8     6.8     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0061   CWE-400 5.0     5.0     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0022   CWE-400 7.8     7.8     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0003   CWE-399 6.1     6.1     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0007   CWE-94  10.0    10.0    0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0031   CWE-400 4.3     4.3     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0052   CWE-287 9.3     9.3     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0062   CWE-20  5.0     5.0     0.0
cpe:/o:juniper:junos:12.1x46    CVE-2018-0001   CWE-416 7.5     7.5     0.0
```