### PR TITLE
[wfn] Make WFNize() behaviour consistent with function documentation.

### DIFF
--- a/wfn/fsb.go
+++ b/wfn/fsb.go
@@ -136,8 +136,8 @@ func addSlashesAt(s string, at int) (string, int, error) {
 		}
 		switch c {
 		case '\\':
-			b = append(b, c, s[i+1])
 			i++
+			b = append(b, c, s[i])
 			embedded = true
 		case '*':
 			// An unquoted asterisk must appear at the beginning or end of the string

--- a/wfn/wfn.go
+++ b/wfn/wfn.go
@@ -81,13 +81,20 @@ func WFNize(s string) (string, error) {
 	in := strings.Replace(s, " ", "_", -1)
 	buf := make([]byte, 0, len(in))
 	// remove illegal characters
-	for _, c := range in {
+	for n, c := range in {
 		c := byte(c)
 		if c >= 'A' && c <= 'Z' ||
 			c >= 'a' && c <= 'z' ||
 			c >= '0' && c <= '9' ||
 			c == '_' ||
 			strings.IndexByte(allowedPunct, c) != -1 {
+			buf = append(buf, c)
+		}
+		// handle wildcard characters
+		if c == '*' || c == '?' {
+			if n == 0 || in[n-1] != '\\' {
+				buf = append(buf, '\\')
+			}
 			buf = append(buf, c)
 		}
 	}

--- a/wfn/wfn_test.go
+++ b/wfn/wfn_test.go
@@ -18,17 +18,25 @@ import "testing"
 
 func TestWFNize(t *testing.T) {
 	cases := []struct {
-		in       string
-		expected string
+		in        string
+		expected  string
+		expectErr bool
 	}{
-		{"Zonealarm Wireless Security", "Zonealarm_Wireless_Security"},
-		{"1.8.14.6001", `1\.8\.14\.6001`},
-		{"xorg-server", `xorg\-server`},
+		{"Zonealarm Wireless Security", "Zonealarm_Wireless_Security", false},
+		{"1.8.14.6001", `1\.8\.14\.6001`, false},
+		{"xorg-server", `xorg\-server`, false},
+		{`1.8.\*`, `1\.8\.*`, false},
+		{"1.*.14", `1\.\*\.14`, false},
+		{`1.\*.14`, "", true},
 	}
 	for _, c := range cases {
 		res, err := WFNize(c.in)
 		if err != nil {
-			t.Errorf("WFNize(%q) returned error: %v", c.in, err)
+			if !c.expectErr {
+				t.Errorf("WFNize(%q) returned error: %v", c.in, err)
+			}
+		} else if c.expectErr {
+			t.Errorf("WFNize(%q) was expected to fail, but succedeed", c.in)
 		} else if res != c.expected {
 			t.Errorf("WFNize(%q) returned %q, %q was expected", c.in, res, c.expected)
 		}


### PR DESCRIPTION
The docstring says:
```
Quoted wildcards (*?) become unquoted ones (i.e. act as wildcards, not a literal '*' and '?')
```
yet the function completely disregrads '*' and '?' characters and just drops them from the output.

This makes it behave as described (also see additional test cases in wfn_test.go).