### PR TITLE
Be a bit more defensive when parsing JSON feed.

### DIFF
--- a/cvefeed/dictionary.go
+++ b/cvefeed/dictionary.go
@@ -76,7 +76,9 @@ func LoadFeed(loadFunc func(string) ([]CVEItem, error), paths ...string) (Dictio
 	go func() {
 		for d := range dictChan {
 			for _, cve := range d {
-				dict[cve.CVEID()] = cve
+				if cveid := cve.CVEID(); cveid != "" {
+					dict[cveid] = cve
+				}
 			}
 		}
 		close(done)

--- a/cvefeed/internal/nvdjson/interfaces.go
+++ b/cvefeed/internal/nvdjson/interfaces.go
@@ -15,6 +15,7 @@
 package nvdjson
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/facebookincubator/nvdtools/cvefeed/internal/iface"
@@ -25,11 +26,17 @@ import (
 
 // CVEID returns the identifier of the vulnerability (e.g. CVE).
 func (i *NVDCVEFeedJSON10DefCVEItem) CVEID() string {
+	if i == nil {
+		return ""
+	}
 	return i.CVE.CVEDataMeta.ID
 }
 
 // Config returns a set of tests that identify vulnerable platform.
 func (i *NVDCVEFeedJSON10DefCVEItem) Config() []iface.LogicalTest {
+	if i == nil || i.Configurations == nil {
+		return nil
+	}
 	return i.Configurations.ifaceNodes
 }
 
@@ -72,19 +79,25 @@ func (i *NVDCVEFeedJSON10DefCVEItem) CVSS30base() float64 {
 
 // LogicalOperator implements part of cvefeed.LogicalTest interface
 func (n *NVDCVEFeedJSON10DefNode) LogicalOperator() string {
+	if n == nil {
+		return ""
+	}
 	return n.Operator
 }
 
 // NegateIfNeeded implements part of cvefeed.LogicalTest interface
 func (n *NVDCVEFeedJSON10DefNode) NegateIfNeeded(b bool) bool {
-	if n.Negate {
-		return !b
+	if n == nil || !n.Negate {
+		return b
 	}
-	return b
+	return !b
 }
 
 // InnerTests implements part of cvefeed.LogicalTest interface
 func (n *NVDCVEFeedJSON10DefNode) InnerTests() []iface.LogicalTest {
+	if n == nil {
+		return nil
+	}
 	if len(n.ifaceChildren) != 0 {
 		return n.ifaceChildren
 	}
@@ -100,6 +113,9 @@ func (n *NVDCVEFeedJSON10DefNode) InnerTests() []iface.LogicalTest {
 
 // CPEs implements part of cvefeed.LogicalTest interface
 func (n *NVDCVEFeedJSON10DefNode) CPEs() []*wfn.Attributes {
+	if n == nil {
+		return nil
+	}
 	if len(n.wfnCPEs) != 0 {
 		return n.wfnCPEs
 	}
@@ -118,6 +134,9 @@ func (n *NVDCVEFeedJSON10DefNode) CPEs() []*wfn.Attributes {
 
 // MatchPlatform implements part of cvefeed.LogicalTest interface
 func (n *NVDCVEFeedJSON10DefNode) MatchPlatform(platform *wfn.Attributes, requireVersion bool) bool {
+	if n == nil {
+		return false
+	}
 	for _, cpeNode := range n.CPEMatch {
 		cpe, err := node2CPE(cpeNode)
 		if err != nil {
@@ -163,6 +182,9 @@ func (n *NVDCVEFeedJSON10DefNode) MatchPlatform(platform *wfn.Attributes, requir
 
 func node2CPE(node *NVDCVEFeedJSON10DefCPEMatch) (*wfn.Attributes, error) {
 	var err error
+	if node == nil {
+		return nil, fmt.Errorf("cannot collect CPEs from nil node")
+	}
 	if node.wfname != nil {
 		return node.wfname, nil
 	}

--- a/cvefeed/internal/nvdjson/nvdjson.go
+++ b/cvefeed/internal/nvdjson/nvdjson.go
@@ -39,18 +39,24 @@ func reparse(root *NVDCVEFeedJSON10) ([]iface.CVEItem, error) {
 	if len(srcItems) == 0 {
 		return nil, fmt.Errorf("NVD CVE JSON feed had no CVE_Items element")
 	}
-	items := make([]iface.CVEItem, len(srcItems))
-	for i, item := range srcItems {
+	items := make([]iface.CVEItem, 0, len(srcItems))
+	for _, item := range srcItems {
+		if item == nil || item.Configurations == nil {
+			continue
+		}
 		for _, node := range item.Configurations.Nodes {
 			reparseLogicalTest(node)
 			item.Configurations.ifaceNodes = append(item.Configurations.ifaceNodes, iface.LogicalTest(node))
 		}
-		items[i] = iface.CVEItem(item)
+		items = append(items, iface.CVEItem(item))
 	}
 	return items, nil
 }
 
 func reparseLogicalTest(node *NVDCVEFeedJSON10DefNode) {
+	if node == nil {
+		return
+	}
 	for _, innerNode := range node.Children {
 		reparseLogicalTest(innerNode)
 	}

--- a/cvefeed/matching_json_test.go
+++ b/cvefeed/matching_json_test.go
@@ -22,6 +22,16 @@ import (
 	"github.com/facebookincubator/nvdtools/wfn"
 )
 
+func TestBadJSONfeed(t *testing.T) {
+	items, err := ParseJSON(bytes.NewBufferString(testJSONdictBroken))
+	if err != nil {
+		t.Fatalf("failed to parse the dictionary: %v", err)
+	}
+	if len(items) > 0 {
+		t.Fatalf("expected the broken feed to be ignored, got %d items", len(items))
+	}
+}
+
 func TestMatchJSON(t *testing.T) {
 	cases := []struct {
 		Rule      int
@@ -136,6 +146,29 @@ func BenchmarkMatchJSON(b *testing.B) {
 		}
 	}
 }
+
+var testJSONdictBroken = `{
+  "CVE_data_format":"",
+  "CVE_data_type":"",
+  "CVE_data_version":"",
+  "CVE_Items":[
+    {},
+    {"cve":null},
+    {
+      "cve": {
+        "data_type" : "CVE",
+        "data_format" : "MITRE",
+        "data_version" : "4.0",
+        "CVE_data_meta" : {
+          "ID" : "TESTVE-2018-0001",
+          "ASSIGNER" : "cve@mitre.org"
+        }
+      },
+      "configurations": null
+    }
+  ]
+}
+`
 
 var testJSONdict = `{
 "CVE_data_type" : "CVE",


### PR DESCRIPTION
We have ran into an issue, when our feed had a malformed item, which led to a processor crash. Reproducable like this:

```
$ cat ~/stuff/feed.json
{"CVE_data_format":"","CVE_data_type":"","CVE_data_version":"","CVE_Items":[{"cve":null}]}

$ echo "cpe:/a:product:version" | ./cpe2cve --feed=json -cpe=1 -cve=2 ~/stuff/feed.json
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x10f5571]

goroutine 6 [running]:
github.com/facebookincubator/nvdtools/cvefeed/internal/nvdjson.reparse(0xc4200b2070, 0x1126760, 0xc4200b2070, 0x0, 0x0, 0x113cf40)
        /Users/dvl/go/src/github.com/facebookincubator/nvdtools/cvefeed/internal/nvdjson/nvdjson.go:44 +0x241
github.com/facebookincubator/nvdtools/cvefeed/internal/nvdjson.Parse(0x17a5030, 0xc420058440, 0xc420058440, 0x17a5030, 0xc420058440, 0x0, 0x10292c9)
        /Users/dvl/go/src/github.com/facebookincubator/nvdtools/cvefeed/internal/nvdjson/nvdjson.go:34 +0x113
github.com/facebookincubator/nvdtools/cvefeed.ParseJSON(0x1181da0, 0xc42000e038, 0x0, 0x0, 0x0, 0x0, 0x0)
        /Users/dvl/go/src/github.com/facebookincubator/nvdtools/cvefeed/cvefeed.go:67 +0x173
github.com/facebookincubator/nvdtools/cvefeed.loadJSONFile(0x7ffeefbff89c, 0x1a, 0x0, 0x0, 0x0, 0x0, 0x0)
        /Users/dvl/go/src/github.com/facebookincubator/nvdtools/cvefeed/dictionary.go:119 +0x1b4
github.com/facebookincubator/nvdtools/cvefeed.LoadFeed.func1(0xc420018160, 0x116f7e8, 0xc420078120, 0xc4200780c0, 0x7ffeefbff89c, 0x1a)
        /Users/dvl/go/src/github.com/facebookincubator/nvdtools/cvefeed/dictionary.go:68 +0x82
created by github.com/facebookincubator/nvdtools/cvefeed.LoadFeed
        /Users/dvl/go/src/github.com/facebookincubator/nvdtools/cvefeed/dictionary.go:66 +0x190
```

With this commit I've added a bunch of nil-checks in crucial places, I probably did not cover everything, but sure it beats having none such checks:

```
$ cat ~/stuff/feed.json
{
  "CVE_data_format":"",
  "CVE_data_type":"",
  "CVE_data_version":"",
  "CVE_Items":[
    {},
    {"cve":null},
    {
      "cve": {
        "data_type" : "CVE",
        "data_format" : "MITRE",
        "data_version" : "4.0",
        "CVE_data_meta" : {
          "ID" : "TESTVE-2018-0001",
          "ASSIGNER" : "cve@mitre.org"
        }
      },
      "configurations": null
    }
  ]
}
$ echo "cpe:/a:product:version" | ./cpe2cve --feed=json -cpe=1 -cve=2 ~/stuff/feed.json
$
```

Also added a unit-test for this, the usual stuff.