### PR TITLE
Don't match version of logical value N/A against version ranges.

### DIFF
--- a/cvefeed/internal/nvdjson/interfaces.go
+++ b/cvefeed/internal/nvdjson/interfaces.go
@@ -161,6 +161,9 @@ func (n *NVDCVEFeedJSON10DefNode) MatchPlatform(platform *wfn.Attributes, requir
 				cpeNode.VersionEndIncluding == "" && cpeNode.VersionEndExcluding == "" {
 				return true
 			}
+			if cpe.Version == wfn.NA {
+				return false
+			}
 			ver := wfn.StripSlashes(platform.Version)
 			if cpeNode.VersionStartIncluding != "" && smartVerCmp(ver, cpeNode.VersionStartIncluding) < 0 {
 				continue


### PR DESCRIPTION
Accordingly to CPE spec version=N/A matches version=Any.
When we have version ranges in our feed, the version of CPE is usually set to Any to allow range match.
But version=N/A should not match any range, yet now it might. This fixes it.