### PR TITLE
Cpe2.3 support for cpe2cve

### DIFF
--- a/cmd/cpe2cve/cpe2cve.go
+++ b/cmd/cpe2cve/cpe2cve.go
@@ -116,9 +116,9 @@ func process(in <-chan []string, out chan<- []string, cache *cvefeed.Cache, cfg 
 		cpeList := strings.Split(rec[cpesAt], cfg.inRecSep)
 		cpes := make([]*wfn.Attributes, len(cpeList))
 		for i, uri := range cpeList {
-			attr, err := wfn.UnbindURI(uri)
+			attr, err := wfn.Parse(uri)
 			if err != nil {
-				glog.Errorf("couldn't unbind uri %q: %v", uri, err)
+				glog.Errorf("couldn't parse uri %q: %v", uri, err)
 				continue
 			}
 			cpes[i] = attr


### PR DESCRIPTION
Summary:
It was a simple change. Instead of calling unbindPrefix directly, just call parse which will try to parse it first as cpe 2.2 and then 2.3

Test Plan:
→ echo 'cpe:2.3:a:*:k8s.io/kubernetes:*:*:*:*:*:*:*:*' | go run ./cmd/cpe2cve  -nproc 24 -idxd -cpe 1 -cve 1 -e 1 -feed json $f
SNYK-GOLANG-K8SIOKUBERNETES-50026
SNYK-GOLANG-K8SIOKUBERNETES-50004
SNYK-GOLANG-K8SIOKUBERNETES-50019