### PR TITLE
Add rustsec2nvd converter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 dist: xenial
 
 go:
-- '1.9'
+- '1.10'
 - 1.x
 - master
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The [HOWTO](HOWTO.md) provides a broader view on how to effectively use these to
 
 ## Requirements
 
-* Go 1.9 or newer
+* Go 1.10 or newer
 
 ## Installation
 

--- a/cmd/rustsec2nvd/rustsec2nvd.go
+++ b/cmd/rustsec2nvd/rustsec2nvd.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/facebookincubator/nvdtools/providers/rustsec"
+
+	"github.com/golang/glog"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: rustsec2nvd <rustsec-crates-dir>")
+		fmt.Println("Example:")
+		fmt.Println("git clone https://github.com/RustSec/advisory-db")
+		fmt.Println("rustsec2nvd advisory-db/crates > rustsec.cve.json")
+		os.Exit(1)
+	}
+
+	feed, err := rustsec.Convert(os.Args[1])
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	err = json.NewEncoder(os.Stdout).Encode(feed)
+	if err != nil {
+		glog.Fatal(err)
+	}
+}

--- a/cvefeed/nvdcommon/nvdcommon.go
+++ b/cvefeed/nvdcommon/nvdcommon.go
@@ -21,6 +21,9 @@ import (
 	"github.com/facebookincubator/nvdtools/wfn"
 )
 
+// TimeLayout is the layout of NVD CVE timestamps.
+const TimeLayout = "2006-01-02T15:04Z"
+
 // LogicalTest describes logical test performed during matching
 type LogicalTest interface {
 	LogicalOperator() string // "and", "or", "eq"

--- a/providers/rustsec/rustsec.go
+++ b/providers/rustsec/rustsec.go
@@ -1,0 +1,269 @@
+// Package rustsec provides a converter for rustsec advisories to nvd.
+package rustsec
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/facebookincubator/nvdtools/cvefeed/nvdcommon"
+	"github.com/facebookincubator/nvdtools/cvefeed/nvdjson"
+	"github.com/facebookincubator/nvdtools/wfn"
+
+	"github.com/BurntSushi/toml"
+	"github.com/pkg/errors"
+)
+
+// Convert scans a directory recursively for rustsec advisory files and convert to NVD CVE JSON 1.0 format.
+func Convert(dir string) (*nvdjson.NVDCVEFeedJSON10, error) {
+	feed := &nvdjson.NVDCVEFeedJSON10{}
+
+	walker := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		_, fn := filepath.Split(path)
+		if !(strings.HasPrefix(fn, "RUSTSEC") && strings.HasSuffix(fn, ".toml")) {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		cve, err := ConvertAdvisory(f)
+		if err != nil {
+			return errors.Wrapf(err, "error parsing file: %s", path)
+		}
+		feed.CVEItems = append(feed.CVEItems, cve)
+		return nil
+	}
+
+	err := filepath.Walk(dir, walker)
+	if err != nil {
+		return nil, err
+	}
+
+	return feed, nil
+}
+
+// ConvertAdvisory converts the rustsec toml advisory data from r to NVD CVE JSON 1.0 format.
+func ConvertAdvisory(r io.Reader) (*nvdjson.NVDCVEFeedJSON10DefCVEItem, error) {
+	var spec advisoryFile
+	_, err := toml.DecodeReader(r, &spec)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot decode rustsec toml advisory")
+	}
+
+	return spec.Item.Convert()
+}
+
+// advisoryFile is the toml spec for rustsec advisories.
+// Ref: https://github.com/RustSec/advisory-db
+type advisoryFile struct {
+	Item advisoryItem `toml:"advisory"`
+}
+
+type advisoryItem struct {
+	ID                 string   `toml:"id"`
+	Package            string   `toml:"package"`
+	Date               string   `toml:"date"`
+	Title              string   `toml:"title"`
+	Description        string   `toml:"description"`
+	URL                string   `toml:"url"`
+	Aliases            []string `toml:"aliases"`
+	Keywords           []string `toml:"keywords"`
+	References         []string `toml:"references"`
+	PatchedVersions    []string `toml:"patched_versions"`
+	AffectedArch       []string `toml:"affected_arch"`
+	AffectedOS         []string `toml:"affected_os"`
+	AffectedFunctions  []string `toml:"affected_functions"`
+	UnaffectedVersions []string `toml:"unaffected_versions"`
+}
+
+const advisoryTimeLayout = "2006-01-02"
+
+func (item *advisoryItem) Convert() (*nvdjson.NVDCVEFeedJSON10DefCVEItem, error) {
+	// TODO: Add CVSS score: https://github.com/RustSec/advisory-db/issues/20
+
+	t, err := time.Parse(advisoryTimeLayout, item.Date)
+	if err != nil {
+		return nil, errors.Wrapf(err, "malformed date layout in %#v: %q", item, item.Date)
+	}
+
+	conf, err := item.newConfigurations()
+	if err != nil {
+		return nil, err
+	}
+
+	cve := &nvdjson.NVDCVEFeedJSON10DefCVEItem{
+		CVE: &nvdjson.CVEJSON40{
+			CVEDataMeta: &nvdjson.CVEJSON40CVEDataMeta{
+				ID:       item.ID,
+				ASSIGNER: "RustSec",
+			},
+			DataFormat:  "MITRE",
+			DataType:    "CVE",
+			DataVersion: "4.0",
+			Description: &nvdjson.CVEJSON40Description{
+				DescriptionData: []*nvdjson.CVEJSON40LangString{
+					{
+						Lang:  "en",
+						Value: item.Description,
+					},
+				},
+			},
+			References: item.newReferences(),
+		},
+		Configurations:   conf,
+		LastModifiedDate: t.Format(nvdcommon.TimeLayout),
+		PublishedDate:    t.Format(nvdcommon.TimeLayout),
+	}
+
+	return cve, nil
+}
+
+func (item *advisoryItem) newReferences() *nvdjson.CVEJSON40References {
+	if len(item.References) == 0 {
+		return nil
+	}
+
+	nrefs := 1 + len(item.Aliases) + len(item.References)
+	refs := &nvdjson.CVEJSON40References{
+		ReferenceData: make([]*nvdjson.CVEJSON40Reference, 0, nrefs),
+	}
+
+	addRef := func(name, url string) {
+		refs.ReferenceData = append(refs.ReferenceData, &nvdjson.CVEJSON40Reference{
+			Name: name,
+			URL:  url,
+		})
+	}
+
+	if item.Title != "" || item.URL != "" {
+		addRef(item.Title, item.URL)
+	}
+
+	for _, ref := range item.Aliases {
+		addRef(ref, "")
+	}
+
+	for _, ref := range item.References {
+		addRef(ref, "")
+	}
+
+	rd := refs.ReferenceData
+	sort.Slice(rd, func(i, j int) bool {
+		return strings.Compare(rd[i].Name, rd[j].Name) < 0
+	})
+
+	return refs
+}
+
+func (item *advisoryItem) newConfigurations() (*nvdjson.NVDCVEFeedJSON10DefConfigurations, error) {
+	pkg, err := wfn.WFNize(item.Package)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot wfn-ize: %q", item.Package)
+	}
+	cpe := wfn.Attributes{Part: "a", Product: pkg}
+	cpe22uri := cpe.BindToURI()
+	cpe23uri := cpe.BindToFmtString()
+
+	matches := []*nvdjson.NVDCVEFeedJSON10DefCPEMatch{}
+	unnafected := append(item.UnaffectedVersions, item.PatchedVersions...)
+
+	for _, version := range unnafected {
+		if len(version) < 2 {
+			return nil, errors.Errorf("malformed version schema in %#v: %q", item, version)
+		}
+
+		var curver string
+
+		switch version[:1] {
+		case "=", "^":
+			curver = strings.TrimSpace(version[1:])
+			wfnver, err := wfn.WFNize(curver)
+			if err != nil {
+				return nil, errors.Wrapf(err, "cannot wfn-ize version: %q", curver)
+			}
+			cpe := wfn.Attributes{Part: "a", Product: pkg, Version: wfnver}
+			cpe22uri := cpe.BindToURI()
+			cpe23uri := cpe.BindToFmtString()
+			match := &nvdjson.NVDCVEFeedJSON10DefCPEMatch{
+				CPEName: []*nvdjson.NVDCVEFeedJSON10DefCPEName{
+					{
+						Cpe22Uri: cpe22uri,
+						Cpe23Uri: cpe23uri,
+					},
+				},
+				Cpe23Uri:   cpe23uri,
+				Vulnerable: version[:1] == "=",
+			}
+			matches = append(matches, match)
+
+		case ">", "<":
+			match := &nvdjson.NVDCVEFeedJSON10DefCPEMatch{
+				CPEName: []*nvdjson.NVDCVEFeedJSON10DefCPEName{
+					{
+						Cpe22Uri: cpe22uri,
+						Cpe23Uri: cpe23uri,
+					},
+				},
+				Cpe23Uri:   cpe23uri,
+				Vulnerable: false, // these are patched + unaffected versions
+			}
+			curver = strings.TrimSpace(version[2:])
+			switch version[:2] {
+			case "> ":
+				match.VersionStartExcluding = curver
+			case ">=":
+				match.VersionStartIncluding = curver
+			case "< ":
+				match.VersionEndExcluding = curver
+			case "<=":
+				match.VersionEndIncluding = curver
+			default:
+				return nil, errors.Errorf("malformed version schema in %#v: %q", item, version)
+			}
+			matches = append(matches, match)
+
+		default:
+			return nil, errors.Errorf("malformed version schema in %#v: %q", item, version)
+		}
+	}
+
+	conf := &nvdjson.NVDCVEFeedJSON10DefConfigurations{
+		CVEDataVersion: "4.0",
+		Nodes: []*nvdjson.NVDCVEFeedJSON10DefNode{
+			{
+				Operator: "AND",
+				Children: []*nvdjson.NVDCVEFeedJSON10DefNode{
+					{
+						CPEMatch: []*nvdjson.NVDCVEFeedJSON10DefCPEMatch{
+							{
+								CPEName: []*nvdjson.NVDCVEFeedJSON10DefCPEName{
+									{
+										Cpe22Uri: cpe22uri,
+										Cpe23Uri: cpe23uri,
+									},
+								},
+								Cpe23Uri:              cpe23uri,
+								Vulnerable:            false,
+								VersionStartIncluding: "0",
+							},
+						},
+					},
+					{
+						Negate:   true,
+						CPEMatch: matches,
+					},
+				},
+			},
+		},
+	}
+
+	return conf, nil
+}

--- a/providers/rustsec/rustsec_test.go
+++ b/providers/rustsec/rustsec_test.go
@@ -1,0 +1,248 @@
+package rustsec
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestConvertAdvisory(t *testing.T) {
+	cve, err := ConvertAdvisory(bytes.NewBufferString(sampleAdvisory))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetIndent("", "\t")
+
+	err = enc.Encode(cve)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	have := b.String()
+	want := goldenCVE
+
+	err = diff(have, want)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func diff(a, b string) error {
+	f1, err := ioutil.TempFile("", "rustsec2nvd")
+	if err != nil {
+		return err
+	}
+	defer f1.Close()
+
+	f2, err := ioutil.TempFile("", "rustsec2nvd")
+	if err != nil {
+		return err
+	}
+	defer f2.Close()
+
+	if _, err = io.WriteString(f1, a); err != nil {
+		return err
+	}
+
+	if _, err = io.WriteString(f2, b); err != nil {
+		return err
+	}
+
+	var ob, eb bytes.Buffer
+	cmd := exec.Command("diff", f1.Name(), f2.Name())
+	cmd.Stdout = &ob
+	cmd.Stderr = &eb
+
+	err = cmd.Run()
+	if err != nil {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%v\n", err)
+		fmt.Fprintf(&sb, "diff command: diff %s %s\n", f1.Name(), f2.Name())
+		fmt.Fprintf(&sb, "diff stdout:\n%s\n--end--\n", ob.String())
+		fmt.Fprintf(&sb, "diff stderr:\n%s\n--end--\n", eb.String())
+		return errors.New(sb.String())
+	}
+
+	return nil
+}
+
+// copied from https://github.com/RustSec/advisory-db
+// uncommented all settings, added patched ^1.2.1
+var sampleAdvisory = `
+[advisory]
+# Identifier for the advisory (mandatory). Will be assigned a "RUSTSEC-YYYY-NNNN"
+# identifier e.g. RUSTSEC-2018-0001. Please use "RUSTSEC-0000-0000" in PRs.
+id = "RUSTSEC-0000-0000"
+
+# Name of the affected crate (mandatory)
+package = "mycrate"
+
+# Disclosure date of the advisory as an RFC 3339 date (mandatory)
+date = "2017-02-25"
+
+# Single-line description of a vulnerability (mandatory)
+title = "Flaw in X allows Y"
+
+# Enter a short-form description of the vulnerability here (mandatory)
+description = """
+Affected versions of this crate did not properly X.
+
+This allows an attacker to Y.
+ 
+The flaw was corrected by Z.
+"""
+
+# Versions which include fixes for this vulnerability (mandatory)
+patched_versions = [">= 1.2.0", "^1.2.1"]
+
+# Versions which were never vulnerable (optional)
+unaffected_versions = ["< 1.1.0"]
+
+# URL to a long-form description of this issue, e.g. a GitHub issue/PR,
+# a change log entry, or a blogpost announcing the release (optional)
+url = "https://github.com/mystuff/mycrate/issues/123"
+
+# Keywords which describe this vulnerability, similar to Cargo (optional)
+keywords = ["ssl", "mitm"]
+
+# Vulnerability aliases, e.g. CVE IDs (optional but recommended)
+# Request a CVE for your RustSec vulns: https://iwantacve.org/
+aliases = ["CVE-2018-XXXX"]
+
+# References to related vulnerabilities (optional)
+# e.g. CVE for a C library wrapped by a -sys crate)
+references = ["CVE-2018-YYYY", "CVE-2018-ZZZZ"]
+
+# CPU architectures impacted by this vulnerability (optional)
+# For a list of CPU architecture strings, see the "platforms" crate:
+# <https://docs.rs/platforms/latest/platforms/target/enum.Arch.html>
+affected_arch = ["x86", "x86_64"]
+
+# Operating systems impacted by this vulnerability (optional)
+# For a list of OS strings, see the "platforms" crate:
+# <https://docs.rs/platforms/latest/platforms/target/enum.OS.html>
+affected_os = ["windows"]
+
+# List of canonical paths to vulnerable functions (optional) 
+# The path syntax is cratename::path::to::function, without any
+# return type or parameters. More information:
+# <https://github.com/RustSec/advisory-db/issues/68>
+# For example, for RUSTSEC-2018-0003, this would look like:
+affected_functions = ["smallvec::SmallVec::insert_many"]
+`
+
+var goldenCVE = `{
+	"cve": {
+		"affects": null,
+		"CVE_data_meta": {
+			"ASSIGNER": "RustSec",
+			"ID": "RUSTSEC-0000-0000"
+		},
+		"data_format": "MITRE",
+		"data_type": "CVE",
+		"data_version": "4.0",
+		"description": {
+			"description_data": [
+				{
+					"lang": "en",
+					"value": "Affected versions of this crate did not properly X.\n\nThis allows an attacker to Y.\n \nThe flaw was corrected by Z.\n"
+				}
+			]
+		},
+		"problemtype": null,
+		"references": {
+			"reference_data": [
+				{
+					"name": "CVE-2018-XXXX",
+					"url": ""
+				},
+				{
+					"name": "CVE-2018-YYYY",
+					"url": ""
+				},
+				{
+					"name": "CVE-2018-ZZZZ",
+					"url": ""
+				},
+				{
+					"name": "Flaw in X allows Y",
+					"url": "https://github.com/mystuff/mycrate/issues/123"
+				}
+			]
+		}
+	},
+	"configurations": {
+		"CVE_data_version": "4.0",
+		"nodes": [
+			{
+				"children": [
+					{
+						"cpe_match": [
+							{
+								"cpe_name": [
+									{
+										"cpe22Uri": "cpe:/a::mycrate",
+										"cpe23Uri": "cpe:2.3:a:*:mycrate:*:*:*:*:*:*:*:*"
+									}
+								],
+								"cpe23Uri": "cpe:2.3:a:*:mycrate:*:*:*:*:*:*:*:*",
+								"versionStartIncluding": "0",
+								"vulnerable": false
+							}
+						]
+					},
+					{
+						"cpe_match": [
+							{
+								"cpe_name": [
+									{
+										"cpe22Uri": "cpe:/a::mycrate",
+										"cpe23Uri": "cpe:2.3:a:*:mycrate:*:*:*:*:*:*:*:*"
+									}
+								],
+								"cpe23Uri": "cpe:2.3:a:*:mycrate:*:*:*:*:*:*:*:*",
+								"versionEndExcluding": "1.1.0",
+								"vulnerable": false
+							},
+							{
+								"cpe_name": [
+									{
+										"cpe22Uri": "cpe:/a::mycrate",
+										"cpe23Uri": "cpe:2.3:a:*:mycrate:*:*:*:*:*:*:*:*"
+									}
+								],
+								"cpe23Uri": "cpe:2.3:a:*:mycrate:*:*:*:*:*:*:*:*",
+								"versionStartIncluding": "1.2.0",
+								"vulnerable": false
+							},
+							{
+								"cpe_name": [
+									{
+										"cpe22Uri": "cpe:/a::mycrate:1.2.1",
+										"cpe23Uri": "cpe:2.3:a:*:mycrate:1.2.1:*:*:*:*:*:*:*"
+									}
+								],
+								"cpe23Uri": "cpe:2.3:a:*:mycrate:1.2.1:*:*:*:*:*:*:*",
+								"vulnerable": false
+							}
+						],
+						"negate": true
+					}
+				],
+				"operator": "AND"
+			}
+		]
+	},
+	"lastModifiedDate": "2017-02-25T00:00Z",
+	"publishedDate": "2017-02-25T00:00Z"
+}
+`


### PR DESCRIPTION
Converter for RustSec TOML advisories to NVD CVE JSON 1.0 feed format.

Besides the unit test for the converter, also tested the generated file
with cpe2cve.

Cloned the repo, generated the NVD CVE JSON feed:

```
git clone https://github.com/RustSec/advisory-db
go run rustsec2nvd.go ./advisory-db/crates/ > rustsec.cve.json
```

Picked a random advisory for testing, e.g. https://github.com/RustSec/advisory-db/blob/master/crates/cookie/RUSTSEC-2017-0005.toml

Checked non-match boundaries:

```
$ echo cpe:/a::cookie:0.5.9 | cpe2cve -require_version -cpe=1 -cve=2 -feed=json rustsec.cve.json
$ echo cpe:/a::cookie:0.6.2 | cpe2cve -require_version -cpe=1 -cve=2 -feed=json rustsec.cve.json
$ echo cpe:/a::cookie:0.7.6 | cpe2cve -require_version -cpe=1 -cve=2 -feed=json rustsec.cve.json
```

Checked matches:

```
$ echo cpe:/a::cookie:0.6.0 | cpe2cve -require_version -cpe=1 -cve=2 -feed=json rustsec.cve.json
cpe:/a::cookie:0.6.0	RUSTSEC-2017-0005
$ echo cpe:/a::cookie:0.6.1 | cpe2cve -require_version -cpe=1 -cve=2 -feed=json rustsec.cve.json
cpe:/a::cookie:0.6.1	RUSTSEC-2017-0005
$ echo cpe:/a::cookie:0.6.3 | cpe2cve -require_version -cpe=1 -cve=2 -feed=json rustsec.cve.json
cpe:/a::cookie:0.6.3	RUSTSEC-2017-0005
$ echo cpe:/a::cookie:0.7.5 | cpe2cve -require_version -cpe=1 -cve=2 -feed=json rustsec.cve.json
cpe:/a::cookie:0.7.5	RUSTSEC-2017-0005
```

Needed to set max version on the CVE configuration to support cpe2cve -require_version.

Closes #40