### PR TITLE
[provider] Add fireeye provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,18 @@ I0820 09:16:29.316352 1197925 cve.go:311] downloading data file "https://static.
 ... more lines skipped ...
 ```
 
+### fireeye2nvd
+
+*fireeye2nvd* downloads the vulnerability data from FireEye and converts it into NVD format. The resulting file can be used as a feed in cpe2cve processor
+
+```bash
+FIREEYE_PUBLIC=public_key
+FIREEYE_PRIVATE=private_key
+fireeye2nvd -since 1h > fireeye_vulns.json
+2019/04/26 03:24:12 fireeye2nvd.go:70: Downloading since Fri, 26 Apr 2019 02:24:12 PDT
+2019/04/26 03:24:12 vulnerability.go:19: Fetching: Start: (Fri, 26 Apr 2019 02:24:12 PDT); End: (Fri, 26 Apr 2019 03:24:12 PDT)
+2019/04/26 03:24:13 vulnerability.go:24: Adding 2 vulns
+```
 
 ## License
 

--- a/cmd/fireeye2nvd/fireeye2nvd.go
+++ b/cmd/fireeye2nvd/fireeye2nvd.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/facebookincubator/nvdtools/providers/fireeye/api"
+	"github.com/facebookincubator/nvdtools/providers/fireeye/converter"
+)
+
+const (
+	baseURL      = "https://api.isightpartners.com"
+	userAgent    = "fireeye2nvd"
+	startOfTimes = int64(1517472000) // 01 Feb 2018, 00:00:00 PST
+)
+
+var (
+	publicKey  string
+	privateKey string
+)
+
+func init() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	publicKey = os.Getenv("FIREEYE_PUBLIC")
+	if publicKey == "" {
+		log.Fatalln("Please set FIREEYE_PUBLIC in environment")
+	}
+	privateKey = os.Getenv("FIREEYE_PRIVATE")
+	if privateKey == "" {
+		log.Fatalln("Please set FIREEYE_PRIVATE in environment")
+	}
+}
+
+func main() {
+	baseURL := flag.String("base_url", baseURL, "FireEye API base URL")
+	sinceDuration := flag.String("since", "", "Golang duration string, use this instead of sinceUnix")
+	sinceUnix := flag.Int64("since_unix", -1, "Unix timestamp since when should we download. If not set, downloads all available data")
+	dontConvert := flag.Bool("dont_convert", false, "Should the feed be converted to NVD format or not")
+	userAgent := flag.String("user_agent", userAgent, "User agent to be used when sending requests")
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [flags]\n", os.Args[0])
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+	flag.Parse()
+
+	since := *sinceUnix
+	if *sinceDuration != "" {
+		dur, err := time.ParseDuration("-" + *sinceDuration)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		since = time.Now().Add(dur).Unix()
+	}
+
+	if since < startOfTimes {
+		since = startOfTimes
+	}
+
+	// create the API
+	client, err := api.NewClient(*baseURL, *userAgent, publicKey, privateKey)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	log.Printf("Downloading since %s\n", time.Unix(since, 0).Format(time.RFC1123))
+	vulns, err := client.FetchAllVulnerabilitiesSince(since)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	if *dontConvert {
+		writeOutput(vulns)
+	} else {
+		writeOutput(converter.Convert(vulns))
+	}
+}
+
+func writeOutput(output interface{}) {
+	if err := json.NewEncoder(os.Stdout).Encode(output); err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/providers/fireeye/api/parameters.go
+++ b/providers/fireeye/api/parameters.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const (
+	ninetyDays = int64(60 * 60 * 24 * 90) // 90 days in seconds, max for FireEye api
+)
+
+type timeRangeParameters struct {
+	StartDate int64
+	EndDate   int64
+}
+
+func (vp timeRangeParameters) String() string {
+	return fmt.Sprintf("Start: (%s); End: (%s)",
+		time.Unix(vp.StartDate, 0).Format(time.RFC1123),
+		time.Unix(vp.EndDate, 0).Format(time.RFC1123),
+	)
+}
+
+func newParametersSince(since int64) timeRangeParameters {
+	return timeRangeParameters{
+		StartDate: since,
+		EndDate:   time.Now().Unix(),
+	}
+}
+
+func (vp timeRangeParameters) validate() error {
+	if vp.StartDate < 0 {
+		return fmt.Errorf("Start date (%d) can't be < 0 ", vp.StartDate)
+	}
+	if vp.EndDate < 0 {
+		return fmt.Errorf("End date (%d) can't be < 0 ", vp.EndDate)
+	}
+	if vp.EndDate < vp.StartDate {
+		return fmt.Errorf("End date can't be < start date: %s", vp)
+	}
+	return nil
+}
+
+func (vp timeRangeParameters) query() string {
+	query := url.Values{}
+	query.Set("startDate", strconv.FormatInt(vp.StartDate, 10))
+	query.Set("endDate", strconv.FormatInt(vp.EndDate, 10))
+	return query.Encode()
+}
+
+func (vp timeRangeParameters) batchBy(gap int64) []timeRangeParameters {
+	/*
+		  This will create an array of parameters. Each element will have endDate - startDate <= gap
+		  Actually, all but last elements will have endDate - startDate = gap
+		  Last one might have <gap or =gap
+			They will have no overlaps: [i+1].StartDate = [i].EndDate + 1
+
+			[1,11].batchBy(3) = [(1,4),(5,8),(9,11)]
+	*/
+	var params []timeRangeParameters
+	add := func(s, e int64) {
+		params = append(params, timeRangeParameters{
+			StartDate: s,
+			EndDate:   e,
+		})
+	}
+	current := vp.StartDate
+	for {
+		currentEnd := current + gap
+		if currentEnd >= vp.EndDate {
+			break
+		}
+		add(current, currentEnd)
+		current = currentEnd + 1
+	}
+	add(current, vp.EndDate)
+	return params
+}

--- a/providers/fireeye/api/threat.go
+++ b/providers/fireeye/api/threat.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"sync"
+
+	"github.com/facebookincubator/nvdtools/providers/fireeye/schema"
+)
+
+// FetchAllThreatReportsSince will fetch all vulnerabilities with specified parameters
+func (c Client) FetchAllThreatReportsSince(since int64) (<-chan *schema.FireeyeReport, error) {
+	parameters := newParametersSince(since)
+	if err := parameters.validate(); err != nil {
+		return nil, err
+	}
+
+	// fetch indexes
+
+	reportIDs := make(chan string)
+	wgReportIDs := sync.WaitGroup{}
+
+	for _, params := range parameters.batchBy(ninetyDays) {
+		wgReportIDs.Add(1)
+		params := params
+		go func() {
+			defer wgReportIDs.Done()
+			log.Printf("Fetching: %s\n", params)
+			if rIDs, err := c.fetchReportIDs(params); err == nil {
+				for _, rID := range rIDs {
+					reportIDs <- rID
+				}
+			} else {
+				log.Println(err)
+			}
+		}()
+	}
+
+	go func() {
+		wgReportIDs.Wait()
+		close(reportIDs)
+	}()
+
+	// fetch reports
+
+	reports := make(chan *schema.FireeyeReport)
+	wgReports := sync.WaitGroup{}
+
+	for rID := range reportIDs {
+		wgReports.Add(1)
+		rID := rID
+		go func() {
+			defer wgReports.Done()
+			if report, err := c.fetchReport(rID); err == nil {
+				reports <- report
+			} else {
+				log.Println(err)
+			}
+		}()
+	}
+
+	go func() {
+		wgReports.Wait()
+		close(reports)
+	}()
+
+	return reports, nil
+}
+
+func (c Client) fetchReportIDs(parameters timeRangeParameters) ([]string, error) {
+	resp, err := c.Request(fmt.Sprintf("/report/index?intelligenceType=threat&%s", parameters.query()))
+	if err != nil {
+		return nil, err
+	}
+
+	var reportIndex []*schema.FireeyeReportIndexItem
+	if err := json.NewDecoder(resp).Decode(&reportIndex); err != nil {
+		return nil, err
+	}
+
+	reportIDs := make([]string, len(reportIndex))
+	for i := 0; i < len(reportIndex); i++ {
+		reportIDs[i] = reportIndex[i].ReportID
+	}
+
+	return reportIDs, nil
+}
+
+func (c Client) fetchReport(reportID string) (*schema.FireeyeReport, error) {
+	resp, err := c.Request(fmt.Sprintf("/report/%s?detail=full", reportID))
+	if err != nil {
+		return nil, err
+	}
+
+	var wrapper schema.FireeyeReportWrapper
+	if err := json.NewDecoder(resp).Decode(&wrapper); err != nil {
+		return nil, err
+	}
+
+	return &wrapper.Report, nil
+}

--- a/providers/fireeye/api/vulnerability.go
+++ b/providers/fireeye/api/vulnerability.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/facebookincubator/nvdtools/providers/fireeye/schema"
+)
+
+// FetchAllVulnerabilitiesSince will fetch all vulnerabilities with specified parameters
+func (c Client) FetchAllVulnerabilitiesSince(since int64) ([]*schema.FireeyeVulnerability, error) {
+	parameters := newParametersSince(since)
+	if err := parameters.validate(); err != nil {
+		return nil, err
+	}
+	var vulns []*schema.FireeyeVulnerability
+	for _, params := range parameters.batchBy(ninetyDays) {
+		log.Printf("Fetching: %s\n", params)
+		vs, err := c.fetchVulnerabilities(params)
+		if err != nil {
+			return nil, err
+		}
+		log.Printf("Adding %d vulns\n", len(vs))
+		vulns = append(vulns, vs...)
+	}
+	return vulns, nil
+}
+
+func (c Client) fetchVulnerabilities(parameters timeRangeParameters) ([]*schema.FireeyeVulnerability, error) {
+	resp, err := c.Request(fmt.Sprintf("/view/vulnerability?%s", parameters.query()))
+	if err != nil {
+		return nil, err
+	}
+
+	var vulnerabilities []*schema.FireeyeVulnerability
+	if err := json.NewDecoder(resp).Decode(&vulnerabilities); err != nil {
+		return nil, err
+	}
+
+	return vulnerabilities, nil
+}

--- a/providers/fireeye/converter/converter.go
+++ b/providers/fireeye/converter/converter.go
@@ -1,0 +1,99 @@
+package converter
+
+import (
+	"strings"
+
+	dstSchema "github.com/facebookincubator/nvdtools/cvefeed/nvdjson"
+	srcSchema "github.com/facebookincubator/nvdtools/providers/fireeye/schema"
+)
+
+const (
+	cveDataVersion = "4.0"
+)
+
+// Convert converts FireEye vulnerability to NVD format
+func Convert(items []*srcSchema.FireeyeVulnerability) dstSchema.NVDCVEFeedJSON10 {
+	cveItems := make([]*dstSchema.NVDCVEFeedJSON10DefCVEItem, len(items))
+	for idx, item := range items {
+		cveItems[idx] = convert(item)
+	}
+	return dstSchema.NVDCVEFeedJSON10{CVEItems: cveItems}
+}
+
+func convert(item *srcSchema.FireeyeVulnerability) *dstSchema.NVDCVEFeedJSON10DefCVEItem {
+	return &dstSchema.NVDCVEFeedJSON10DefCVEItem{
+		CVE: &dstSchema.CVEJSON40{
+			CVEDataMeta: &dstSchema.CVEJSON40CVEDataMeta{
+				ID:       makeID(item),
+				ASSIGNER: "fireeye",
+			},
+			DataFormat:  "MITRE",
+			DataType:    "CVE",
+			DataVersion: cveDataVersion,
+			Description: &dstSchema.CVEJSON40Description{
+				DescriptionData: []*dstSchema.CVEJSON40LangString{
+					{Lang: "en", Value: item.Title},
+				},
+			},
+			References: makeReferences(item),
+		},
+		Configurations: makeConfigurations(item),
+		Impact: &dstSchema.NVDCVEFeedJSON10DefImpact{
+			BaseMetricV2: &dstSchema.NVDCVEFeedJSON10DefImpactBaseMetricV2{
+				CVSSV2: &dstSchema.CVSSV20{
+					BaseScore:     extractCVSSBaseScore(item),
+					TemporalScore: extractCVSSTemporalScore(item),
+					VectorString:  extractCVSSVectorString(item),
+				},
+			},
+		},
+		LastModifiedDate: convertTime(item.PublishDate),
+		PublishedDate:    convertTime(item.Version1PublishDate),
+	}
+}
+
+func makeID(item *srcSchema.FireeyeVulnerability) string {
+	return "fireeye-" + item.ReportID
+}
+
+func makeReferences(item *srcSchema.FireeyeVulnerability) *dstSchema.CVEJSON40References {
+	var refsData []*dstSchema.CVEJSON40Reference
+	addRef := func(name, url string) {
+		refsData = append(refsData, &dstSchema.CVEJSON40Reference{
+			Name: name,
+			URL:  url,
+		})
+	}
+
+	addRef("FireEye report API link", item.ReportLink)
+	addRef("FireEye web link", item.WebLink)
+	for _, cve := range item.CVEIds {
+		for _, cveid := range strings.Split(cve, ",") {
+			addRef(cveid, "")
+		}
+	}
+
+	return &dstSchema.CVEJSON40References{
+		ReferenceData: refsData,
+	}
+}
+
+func makeConfigurations(item *srcSchema.FireeyeVulnerability) *dstSchema.NVDCVEFeedJSON10DefConfigurations {
+	var matches []*dstSchema.NVDCVEFeedJSON10DefCPEMatch
+	for _, cpe := range extractCPEs(item) {
+		matches = append(matches, &dstSchema.NVDCVEFeedJSON10DefCPEMatch{
+			Cpe23Uri:   cpe,
+			Vulnerable: true,
+		})
+	}
+
+	return &dstSchema.NVDCVEFeedJSON10DefConfigurations{
+		CVEDataVersion: cveDataVersion,
+		Nodes: []*dstSchema.NVDCVEFeedJSON10DefNode{
+			&dstSchema.NVDCVEFeedJSON10DefNode{
+				CPEMatch: matches,
+				Operator: "OR",
+			},
+		},
+	}
+}

--- a/providers/fireeye/converter/converterutils.go
+++ b/providers/fireeye/converter/converterutils.go
@@ -1,0 +1,40 @@
+package converter
+
+import (
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/facebookincubator/nvdtools/cvefeed/nvdcommon"
+	"github.com/facebookincubator/nvdtools/providers/fireeye/schema"
+)
+
+func extractCVSSBaseScore(item *schema.FireeyeVulnerability) float64 {
+	return strToFloat(item.CvssBaseScore)
+}
+
+func extractCVSSTemporalScore(item *schema.FireeyeVulnerability) float64 {
+	return strToFloat(item.CvssTemporalScore)
+}
+
+func extractCVSSVectorString(item *schema.FireeyeVulnerability) string {
+	return strings.Trim(item.CvssBaseVector, "()")
+}
+
+func extractCPEs(item *schema.FireeyeVulnerability) []string {
+	return strings.Split(item.CPE, ",")
+}
+
+func convertTime(fireeyeTime int64) string {
+	return time.Unix(fireeyeTime, 0).Format(nvdcommon.TimeLayout)
+}
+
+func strToFloat(str string) float64 {
+	f, err := strconv.ParseFloat(str, 64)
+	if err != nil {
+		log.Println(err)
+		f = float64(0)
+	}
+	return f
+}

--- a/providers/fireeye/schema/error.go
+++ b/providers/fireeye/schema/error.go
@@ -1,0 +1,8 @@
+package schema
+
+// FireeyeResultErrorMessage struct
+type FireeyeResultErrorMessage struct {
+	Error       string `json:"error"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+}

--- a/providers/fireeye/schema/report.go
+++ b/providers/fireeye/schema/report.go
@@ -1,0 +1,149 @@
+package schema
+
+// FireeyeReportIndexItem one item in array returned on /report/index
+// we only want the reportID so we can use it to get /report/{reportID}
+type FireeyeReportIndexItem struct {
+	ReportID string `json:"reportId"`
+}
+
+// FireeyeReportWrapper struct
+type FireeyeReportWrapper struct {
+	Report FireeyeReport `json:"report"`
+}
+
+// FireeyeReport struct
+type FireeyeReport struct {
+	Audience            []string                  `json:"audience"`
+	Copyright           string                    `json:"copyright"`
+	CveIDs              *FireeyeReportCveIDs      `json:"cveIds"`
+	ExecSummary         string                    `json:"execSummary"`
+	IntelligenceType    string                    `json:"intelligenceType"`
+	PublishDate         string                    `json:"publishDate"`
+	ReportID            string                    `json:"reportId"`
+	ReportType          string                    `json:"reportType"`
+	TagSection          *FireeyeReportTagSection  `json:"tagSection"`
+	ThreatScape         *FireeyeReportThreatScape `json:"ThreatScape"`
+	Title               string                    `json:"title"`
+	Version             string                    `json:"version"`
+	Version1PublishDate string                    `json:"version1PublishDate"`
+}
+
+// FireeyeReportCveIDs struct
+type FireeyeReportCveIDs struct {
+	CveID []string `json:"cveId"`
+}
+
+// FireeyeReportTagSection struct
+type FireeyeReportTagSection struct {
+	Files    *FireeyeReportFiles    `json:"files"`
+	Main     *FireeyeReportMain     `json:"main"`
+	Networks *FireeyeReportNetworks `json:"networks"`
+}
+
+// FireeyeReportThreatScape struct
+type FireeyeReportThreatScape struct {
+	Product []string `json:"product"`
+}
+
+// FireeyeReportFiles struct
+type FireeyeReportFiles struct {
+	File []*FireeyeReportFile `json:"file"`
+}
+
+// FireeyeReportFile struct
+type FireeyeReportFile struct {
+	Sha1       string `json:"sha1"`
+	Identifier string `json:"identifier"`
+	Actor      string `json:"actor"`
+	FileName   string `json:"fileName"`
+	FileSize   string `json:"fileSize"`
+	ActorID    string `json:"actorId"`
+	Sha256     string `json:"sha256"`
+	Type       string `json:"type"`
+	Md5        string `json:"md5"`
+}
+
+// FireeyeReportMain struct
+type FireeyeReportMain struct {
+	Actors               *FireeyeReportActors               `json:"actors"`
+	AffectedIndustries   *FireeyeReportAffectedIndustries   `json:"affectedIndustries"`
+	IntendedEffects      *FireeyeReportIntendedEffects      `json:"intendedEffects"`
+	MalwareFamilies      *FireeyeReportMalwareFamilies      `json:"malwareFamilies"`
+	Motivations          *FireeyeReportMotivations          `json:"motivations"`
+	SourceGeographies    *FireeyeReportSourceGeographies    `json:"sourceGeographies"`
+	TargetedInformations *FireeyeReportTargetedInformations `json:"targetedInformations"`
+	TargetGeographies    *FireeyeReportTargetGeographies    `json:"targetGeographies"`
+	Ttps                 *FireeyeReportTtps                 `json:"ttps"`
+}
+
+// FireeyeReportActors struct
+type FireeyeReportActors struct {
+	Actor []*FireeyeReportActor `json:"actor"`
+}
+
+// FireeyeReportActor struct
+type FireeyeReportActor struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// FireeyeReportNetworks struct
+type FireeyeReportNetworks struct {
+	Networks []*FireeyeReportNetwork `json:"network"`
+}
+
+// FireeyeReportNetwork struct
+type FireeyeReportNetwork struct {
+	URL         string `json:"url"`
+	NetworkType string `json:"networkType"`
+	Identifier  string `json:"identifier"`
+	Actor       string `json:"actor"`
+	ActorID     string `json:"actorId"`
+	Domain      string `json:"domain"`
+}
+
+// FireeyeReportMotivations struct
+type FireeyeReportMotivations struct {
+	Motivation []string `json:"motivation"`
+}
+
+// FireeyeReportSourceGeographies struct
+type FireeyeReportSourceGeographies struct {
+	SourceGeography []string `json:"sourceGeography"`
+}
+
+// FireeyeReportAffectedIndustries struct
+type FireeyeReportAffectedIndustries struct {
+	AffectedIndustry []string `json:"affectedIndustry"`
+}
+
+// FireeyeReportIntendedEffects struct
+type FireeyeReportIntendedEffects struct {
+	IntendedEffect []string `json:"intendedEffect"`
+}
+
+// FireeyeReportTtps struct
+type FireeyeReportTtps struct {
+	Ttp []string `json:"ttp"`
+}
+
+// FireeyeReportTargetGeographies struct
+type FireeyeReportTargetGeographies struct {
+	TargetGeography []string `json:"targetGeography"`
+}
+
+// FireeyeReportTargetedInformations struct
+type FireeyeReportTargetedInformations struct {
+	TargetedInformation []string `json:"targetedInformation"`
+}
+
+// FireeyeReportMalwareFamilies struct
+type FireeyeReportMalwareFamilies struct {
+	MalwareFamily []*FireeyeReportMalwareFamily `json:"malwareFamily"`
+}
+
+// FireeyeReportMalwareFamily struct
+type FireeyeReportMalwareFamily struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}

--- a/providers/fireeye/schema/result.go
+++ b/providers/fireeye/schema/result.go
@@ -1,0 +1,7 @@
+package schema
+
+// FireeyeResult struct
+type FireeyeResult struct {
+	Success bool        `json:"success"`
+	Message interface{} `json:"message"`
+}

--- a/providers/fireeye/schema/vulnerability.go
+++ b/providers/fireeye/schema/vulnerability.go
@@ -1,0 +1,29 @@
+package schema
+
+// FireeyeVulnerability struct
+type FireeyeVulnerability struct {
+	ThreatScape            []string `json:"ThreatScape"`
+	AttackingEase          string   `json:"attackingEase"`
+	Audience               []string `json:"audience"`
+	CPE                    string   `json:"cpe"`
+	CVEIds                 []string `json:"cveIds"`
+	CVEOriginalReleaseDate int64    `json:"cveOriginalReleaseDate"`
+	CvssBaseScore          string   `json:"cvssBaseScore"`
+	CvssBaseScoreLink      string   `json:"cvssBaseScoreLink"`
+	CvssBaseVector         string   `json:"cvssBaseVector"`
+	CvssTemporalScore      string   `json:"cvssTemporalScore"`
+	CvssTemporalScoreLink  string   `json:"cvssTemporalScoreLink"`
+	CvssTemporalVector     string   `json:"cvssTemporalVector"`
+	ExploitInTheWild       bool     `json:"exploitInTheWild"`
+	ExploitRating          string   `json:"exploitRating"`
+	IntelligenceType       string   `json:"intelligenceType"`
+	Mitigations            []string `json:"mitigations"`
+	PublishDate            int64    `json:"publishDate"`
+	ReportID               string   `json:"reportId"`
+	ReportLink             string   `json:"reportLink"`
+	RiskRating             string   `json:"riskRating"`
+	Title                  string   `json:"title"`
+	Version                string   `json:"version"`
+	Version1PublishDate    int64    `json:"version1PublishDate"`
+	WebLink                string   `json:"webLink"`
+}


### PR DESCRIPTION
Summary:
This diff adds the ability to fetch fireeye data and convert it into NVD format.

Test Plan:
```
$ with_proxy go run ./cmd/fireeye2nvd -since 1h >/dev/null
2019/04/26 03:17:00 fireeye2nvd.go:70: Downloading since Fri, 26 Apr 2019 02:17:00 PDT
2019/04/26 03:17:00 vulnerability.go:19: Fetching: Start: (Fri, 26 Apr 2019 02:17:00 PDT); End: (Fri, 26 Apr 2019 03:17:00 PDT)
2019/04/26 03:17:01 vulnerability.go:24: Adding 16 vulns
$ echo $?
0
```