### PR TITLE
[provider] Remove startOfTImes from providers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ TOOLS = \
 	csv2cpe \
 	fireeye2nvd \
 	flexera2nvd \
+	idefense2nvd \
 	nvdsync \
 	rpm2cpe \
 	rustsec2nvd \
@@ -119,6 +120,7 @@ release_tar:
 	mkdir -p release
 	make deps binary_tar GOOS=darwin GOARCH=amd64
 	make deps binary_tar GOOS=freebsd GOARCH=amd64
+	make deps binary_tar GOOS=freebsd GOARCH=arm
 	make deps binary_tar GOOS=linux GOARCH=amd64
 	make deps binary_tar GOOS=linux GOARCH=arm64
 	mv build/tgz/*.tar.gz release

--- a/cmd/fireeye2nvd/fireeye2nvd.go
+++ b/cmd/fireeye2nvd/fireeye2nvd.go
@@ -27,9 +27,8 @@ import (
 )
 
 const (
-	baseURL      = "https://api.isightpartners.com"
-	userAgent    = "fireeye2nvd"
-	startOfTimes = int64(1517472000) // 01 Feb 2018, 00:00:00 PST
+	baseURL   = "https://api.isightpartners.com"
+	userAgent = "fireeye2nvd"
 )
 
 var (
@@ -51,8 +50,8 @@ func init() {
 
 func main() {
 	baseURL := flag.String("base_url", baseURL, "FireEye API base URL")
-	sinceDuration := flag.String("since", "", "Golang duration string, use this instead of sinceUnix")
-	sinceUnix := flag.Int64("since_unix", -1, "Unix timestamp since when should we download. If not set, downloads all available data")
+	sinceDuration := flag.String("since", "", "Golang duration string, overrides -since_unix flag")
+	sinceUnix := flag.Int64("since_unix", 0, "Unix timestamp since when should we download. If not set, downloads all available data")
 	dontConvert := flag.Bool("dont_convert", false, "Should the feed be converted to NVD format or not")
 	userAgent := flag.String("user_agent", userAgent, "User agent to be used when sending requests")
 	flag.Usage = func() {
@@ -69,10 +68,6 @@ func main() {
 			log.Fatalln(err)
 		}
 		since = time.Now().Add(dur).Unix()
-	}
-
-	if since < startOfTimes {
-		since = startOfTimes
 	}
 
 	// create the API

--- a/cmd/flexera2nvd/flexera2nvd.go
+++ b/cmd/flexera2nvd/flexera2nvd.go
@@ -28,8 +28,7 @@ import (
 )
 
 const (
-	baseURL      = "https://api.app.secunia.com"
-	startOfTimes = int64(1517472000) // 01 Feb 2018, 00:00:00 PST
+	baseURL = "https://api.app.secunia.com"
 )
 
 var (
@@ -46,8 +45,8 @@ func init() {
 
 func main() {
 	baseURL := flag.String("url", baseURL, "Flexera API base URL")
-	sinceDuration := flag.String("since", "", "Golang duration string, use this instead of sinceUnix")
-	sinceUnix := flag.Int64("since_unix", -1, "Unix timestamp since when should we download. If not set, downloads all available data")
+	sinceDuration := flag.String("since", "", "Golang duration string, overrides -since_unix flag")
+	sinceUnix := flag.Int64("since_unix", 0, "Unix timestamp since when should we download. If not set, downloads all available data")
 	only := flag.String("only", "", "If present, it will only download this advisory")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [flags]\n", os.Args[0])
@@ -80,9 +79,6 @@ func main() {
 				log.Fatal(err)
 			}
 			since = time.Now().Add(dur).Unix()
-		}
-		if since < startOfTimes {
-			since = startOfTimes
 		}
 
 		from, to := since, time.Now().Unix()

--- a/cmd/idefense2nvd/idefense2nvd.go
+++ b/cmd/idefense2nvd/idefense2nvd.go
@@ -14,9 +14,8 @@ import (
 )
 
 const (
-	baseURL      = "https://api.intelgraph.idefense.com"
-	endpoint     = "rest/vulnerability/v0"
-	startOfTimes = int64(1517472000) // 01 Feb 2018, 00:00:00 PST - we don't have access before this
+	baseURL  = "https://api.intelgraph.idefense.com"
+	endpoint = "rest/vulnerability/v0"
 )
 
 var (
@@ -35,8 +34,8 @@ func init() {
 func main() {
 	url := flag.String("url", fmt.Sprintf("%s/%s", baseURL, endpoint), "iDefense API endpoint")
 	parametersPath := flag.String("parameters_path", "", "Path to a json file which contains parameters used to query the API")
-	sinceDuration := flag.String("since", "", "Golang duration string, use this instead of sinceUnix")
-	sinceUnix := flag.Int64("since_unix", -1, "Unix timestamp since when should we download. If not set, downloads all available data")
+	sinceDuration := flag.String("since", "", "Golang duration string, overrides -since_unix flag")
+	sinceUnix := flag.Int64("since_unix", 0, "Unix timestamp since when should we download. If not set, downloads all available data")
 	dontConvert := flag.Bool("dont_convert", false, "Should the feed be converted to NVD format or not")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [flags]\n", os.Args[0])
@@ -52,9 +51,6 @@ func main() {
 			log.Fatal(err)
 		}
 		since = time.Now().Add(dur).Unix()
-	}
-	if since < startOfTimes {
-		since = startOfTimes
 	}
 
 	parameters = make(map[string]interface{})

--- a/providers/idefense/schema/script.sed
+++ b/providers/idefense/schema/script.sed
@@ -1,7 +1,7 @@
 # remove the comment
 s/^copy paste.*$//g
 
-# fix first line to remove this stupid signs
+# fix first line to remove these weird signs
 s/SearchResults«Vulnerability»/VulnerabilitySearchResults/g
 
 # remove : Translatable


### PR DESCRIPTION
we don't need this open sourced. Lets just drop it and download all
data, user can still set the boundary with -since_unix or -since flags

also, add idefense2nvd to Makefile