### PR TITLE
[provider][fireeye] Make client goroutine safe

### DIFF
--- a/providers/fireeye/api/threat.go
+++ b/providers/fireeye/api/threat.go
@@ -24,7 +24,7 @@ import (
 )
 
 // FetchAllThreatReportsSince will fetch all vulnerabilities with specified parameters
-func (c Client) FetchAllThreatReportsSince(since int64) (<-chan *schema.FireeyeReport, error) {
+func (c *Client) FetchAllThreatReportsSince(since int64) (<-chan *schema.FireeyeReport, error) {
 	parameters := newParametersSince(since)
 	if err := parameters.validate(); err != nil {
 		return nil, err
@@ -82,7 +82,7 @@ func (c Client) FetchAllThreatReportsSince(since int64) (<-chan *schema.FireeyeR
 	return reports, nil
 }
 
-func (c Client) fetchReportIDs(parameters timeRangeParameters) ([]string, error) {
+func (c *Client) fetchReportIDs(parameters timeRangeParameters) ([]string, error) {
 	resp, err := c.Request(fmt.Sprintf("/report/index?intelligenceType=threat&%s", parameters.query()))
 	if err != nil {
 		return nil, err
@@ -101,7 +101,7 @@ func (c Client) fetchReportIDs(parameters timeRangeParameters) ([]string, error)
 	return reportIDs, nil
 }
 
-func (c Client) fetchReport(reportID string) (*schema.FireeyeReport, error) {
+func (c *Client) fetchReport(reportID string) (*schema.FireeyeReport, error) {
 	resp, err := c.Request(fmt.Sprintf("/report/%s?detail=full", reportID))
 	if err != nil {
 		return nil, err

--- a/providers/fireeye/api/vulnerability.go
+++ b/providers/fireeye/api/vulnerability.go
@@ -23,7 +23,7 @@ import (
 )
 
 // FetchAllVulnerabilitiesSince will fetch all vulnerabilities with specified parameters
-func (c Client) FetchAllVulnerabilitiesSince(since int64) ([]*schema.FireeyeVulnerability, error) {
+func (c *Client) FetchAllVulnerabilitiesSince(since int64) ([]*schema.FireeyeVulnerability, error) {
 	parameters := newParametersSince(since)
 	if err := parameters.validate(); err != nil {
 		return nil, err
@@ -41,7 +41,7 @@ func (c Client) FetchAllVulnerabilitiesSince(since int64) ([]*schema.FireeyeVuln
 	return vulns, nil
 }
 
-func (c Client) fetchVulnerabilities(parameters timeRangeParameters) ([]*schema.FireeyeVulnerability, error) {
+func (c *Client) fetchVulnerabilities(parameters timeRangeParameters) ([]*schema.FireeyeVulnerability, error) {
 	resp, err := c.Request(fmt.Sprintf("/view/vulnerability?%s", parameters.query()))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Summary:
When running multiple goroutines, sha256 internal package panics. I've
debugged this and the problem was that multiple goroutines we're messing
with the same hash.Hash object.
Fixed it by adding a lock to this function

Test:
Fireeye2nvd still works