### PR TITLE
[cvss] Enable parsing of undefined values

### DIFF
--- a/cvss/v2/score.go
+++ b/cvss/v2/score.go
@@ -41,7 +41,7 @@ func (v Vector) environmentalScore() float64 {
 	ai := v.adjustedImpactScore()
 	at := v.temporalScoreWith(ai)
 
-	return roundTo1Decimal((at + (10-at)*v.WeightDefault("CDP", 0.0)) * v.WeightDefault("TD", 1.0))
+	return roundTo1Decimal((at + (10-at)*v.WeightMust("CDP")) * v.WeightMust("TD"))
 }
 
 // helpers
@@ -58,15 +58,15 @@ func (v Vector) adjustedImpactScore() float64 {
 	return math.Min(
 		10.0,
 		10.41*(1-
-			(1-v.WeightMust("C")*v.WeightDefault("CR", 1.0))*
-				(1-v.WeightMust("I")*v.WeightDefault("IR", 1.0))*
-				(1-v.WeightMust("A")*v.WeightDefault("AR", 1.0))),
+			(1-v.WeightMust("C")*v.WeightMust("CR"))*
+				(1-v.WeightMust("I")*v.WeightMust("IR"))*
+				(1-v.WeightMust("A")*v.WeightMust("AR"))),
 	)
 }
 
 func (v Vector) temporalScoreWith(impact float64) float64 {
 	base := v.baseScoreWith(impact)
-	return roundTo1Decimal(base * v.WeightDefault("E", 1.0) * v.WeightDefault("RL", 1.0) * v.WeightDefault("RC", 1.0))
+	return roundTo1Decimal(base * v.WeightMust("E") * v.WeightMust("RL") * v.WeightMust("RC"))
 }
 
 func (v Vector) baseScoreWith(impact float64) float64 {

--- a/cvss/v2/vector.go
+++ b/cvss/v2/vector.go
@@ -21,6 +21,10 @@ import (
 	"github.com/facebookincubator/nvdtools/cvss/common"
 )
 
+const (
+	notDefined = "ND"
+)
+
 var (
 	weights = map[string]map[string]float64{
 
@@ -58,59 +62,59 @@ var (
 
 		// temporal metrics
 		"E": { // Exploitability
-			"U":   0.85, // Unproven
-			"POC": 0.90, // Proof-Of-Concept
-			"F":   0.95, // Functional
-			"H":   1.00, // High
-			"ND":  1.00, // Not Defined
+			"U":        0.85, // Unproven
+			"POC":      0.90, // Proof-Of-Concept
+			"F":        0.95, // Functional
+			"H":        1.00, // High
+			notDefined: 1.00, // Not Defined
 		},
 		"RL": { // Remediation Level
-			"OF": 0.87, // Official Fix
-			"TF": 0.90, // Temporary Fix
-			"W":  0.95, // Workaround
-			"U":  1.00, // Unavailable
-			"ND": 1.00, // Not Defined
+			"OF":       0.87, // Official Fix
+			"TF":       0.90, // Temporary Fix
+			"W":        0.95, // Workaround
+			"U":        1.00, // Unavailable
+			notDefined: 1.00, // Not Defined
 		},
 		"RC": { // Report Confidence
-			"UC": 0.90, // Unconfirmed
-			"UR": 0.95, // Uncorroborated
-			"C":  1.00, // Confirmed
-			"ND": 1.00, // Not
+			"UC":       0.90, // Unconfirmed
+			"UR":       0.95, // Uncorroborated
+			"C":        1.00, // Confirmed
+			notDefined: 1.00, // Not
 		},
 
 		// environmental metrics
 		"CDP": { // Collateral Damage Potential
-			"N":  0.0, // None
-			"L":  0.1, // Low
-			"LM": 0.3, // Low-Medium
-			"MH": 0.4, // Medium-High
-			"H":  0.5, // High
-			"ND": 0.0, // Not Defined
+			"N":        0.0, // None
+			"L":        0.1, // Low
+			"LM":       0.3, // Low-Medium
+			"MH":       0.4, // Medium-High
+			"H":        0.5, // High
+			notDefined: 0.0, // Not Defined
 		},
 		"TD": { // Target Distribution
-			"N":  0.00, // None
-			"L":  0.25, // Low
-			"M":  0.75, // Medium
-			"H":  1.00, // High
-			"ND": 1.00, // Not Defined
+			"N":        0.00, // None
+			"L":        0.25, // Low
+			"M":        0.75, // Medium
+			"H":        1.00, // High
+			notDefined: 1.00, // Not Defined
 		},
 		"CR": { // Confidentiality Requirement
-			"L":  0.50, // Low
-			"M":  1.00, // Medium
-			"H":  1.51, // High
-			"ND": 1.00, // Not Defined
+			"L":        0.50, // Low
+			"M":        1.00, // Medium
+			"H":        1.51, // High
+			notDefined: 1.00, // Not Defined
 		},
 		"IR": { // Integrity Requirement
-			"L":  0.50, // Low
-			"M":  1.00, // Medium
-			"H":  1.51, // High
-			"ND": 1.00, // Not Defined
+			"L":        0.50, // Low
+			"M":        1.00, // Medium
+			"H":        1.51, // High
+			notDefined: 1.00, // Not Defined
 		},
 		"AR": { // Availability Requirement
-			"L":  0.50, // Low
-			"M":  1.00, // Medium
-			"H":  1.51, // High
-			"ND": 1.00, // Not Defined
+			"L":        0.50, // Low
+			"M":        1.00, // Medium
+			"H":        1.51, // High
+			notDefined: 1.00, // Not Defined
 		},
 	}
 
@@ -118,11 +122,11 @@ var (
 )
 
 type Vector struct {
-	common.WeightsMetrics
+	common.Metrics
 }
 
 func NewVector() Vector {
-	return Vector{common.WeightsMetrics{make(common.Metrics), weights}}
+	return Vector{common.NewMetrics(weights, notDefined)}
 }
 
 func (v Vector) Validate() error {
@@ -137,5 +141,5 @@ func (v Vector) Validate() error {
 // Override parse because it can contain parenthesis
 
 func (v Vector) Parse(str string) error {
-	return v.WeightsMetrics.Parse(strings.Trim(str, "()"))
+	return v.Metrics.Parse(strings.Trim(str, "()"))
 }

--- a/cvss/v3/score.go
+++ b/cvss/v3/score.go
@@ -43,7 +43,7 @@ func (v Vector) baseScore() float64 {
 }
 
 func (v Vector) temporalScore() float64 {
-	return roundUp(v.baseScore() * v.WeightDefault("E", 1.0) * v.WeightDefault("RL", 1.0) * v.WeightDefault("RC", 1.0))
+	return roundUp(v.baseScore() * v.WeightMust("E") * v.WeightMust("RL") * v.WeightMust("RC"))
 }
 
 func (v Vector) environmentalScore() float64 {
@@ -56,7 +56,7 @@ func (v Vector) environmentalScore() float64 {
 		c = 1.08
 	}
 
-	return roundUp(roundUp(math.Min(c*(e+i), 10.0)) * v.WeightDefault("E", 1.0) * v.WeightDefault("RL", 1.0) * v.WeightDefault("RC", 1.0))
+	return roundUp(roundUp(math.Min(c*(e+i), 10.0)) * v.WeightMust("E") * v.WeightMust("RL") * v.WeightMust("RC"))
 }
 
 // helpers
@@ -76,9 +76,9 @@ func (v Vector) exploitabilityScore() float64 {
 
 func (v Vector) modifiedImpactScore() float64 {
 	iscModified := math.Min(
-		1-(1-v.modifiedWeight("C")*v.WeightDefault("CR", 1.0))*
-			(1-v.modifiedWeight("I")*v.WeightDefault("IR", 1.0))*
-			(1-v.modifiedWeight("A")*v.WeightDefault("AR", 1.0)),
+		1-(1-v.modifiedWeight("C")*v.WeightMust("CR"))*
+			(1-v.modifiedWeight("I")*v.WeightMust("IR"))*
+			(1-v.modifiedWeight("A")*v.WeightMust("AR")),
 		0.915,
 	)
 	if v.modifiedScopeChanged() {

--- a/cvss/v3/vector.go
+++ b/cvss/v3/vector.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	prefix = "CVSS:3.0/"
+	prefix     = "CVSS:3.0/"
+	notDefined = "X"
 )
 
 var (
@@ -71,38 +72,44 @@ var (
 
 	temporalMetricsWeights = map[string]map[string]float64{
 		"E": { // Exploit Code Maturity
-			"H": 1.00, // High
-			"F": 0.97, // Functional
-			"P": 0.94, // Proof-Of-Concept
-			"U": 0.91, // Unproven
+			notDefined: 1.00, // Not defined
+			"H":        1.00, // High
+			"F":        0.97, // Functional
+			"P":        0.94, // Proof-Of-Concept
+			"U":        0.91, // Unproven
 		},
 		"RL": { // Remediation Level
-			"U": 1.00, // Unavailable
-			"W": 0.97, // Workaround
-			"T": 0.96, // Temporary Fix
-			"O": 0.95, // Official Fix
+			notDefined: 1.00, // Not defined
+			"U":        1.00, // Unavailable
+			"W":        0.97, // Workaround
+			"T":        0.96, // Temporary Fix
+			"O":        0.95, // Official Fix
 		},
 		"RC": { // Report Confidence
-			"C": 1.00, // Confirmed
-			"R": 0.96, // Reasonable
-			"U": 0.92, // Unknown
+			notDefined: 1.00, // Not defined
+			"C":        1.00, // Confirmed
+			"R":        0.96, // Reasonable
+			"U":        0.92, // Unknown
 		},
 	}
 	environmentalMetricsWeights = map[string]map[string]float64{
 		"CR": { // Confidentiality Requirement
-			"H": 1.50, // High
-			"M": 1.00, // Medium
-			"L": 0.50, // Low
+			notDefined: 1.00, // Not defined
+			"H":        1.50, // High
+			"M":        1.00, // Medium
+			"L":        0.50, // Low
 		},
 		"IR": { // Integrity Requirement
-			"H": 1.50, // High
-			"M": 1.00, // Medium
-			"L": 0.50, // Low
+			notDefined: 1.00, // Not defined
+			"H":        1.50, // High
+			"M":        1.00, // Medium
+			"L":        0.50, // Low
 		},
 		"AR": { // Availability Requirement
-			"H": 1.50, // High
-			"M": 1.00, // Medium
-			"L": 0.50, // Low
+			notDefined: 1.00, // Not defined
+			"H":        1.50, // High
+			"M":        1.00, // Medium
+			"L":        0.50, // Low
 		},
 		// + the ones from base vector, see init function below
 	}
@@ -124,11 +131,11 @@ func init() {
 }
 
 type Vector struct {
-	common.WeightsMetrics
+	common.Metrics
 }
 
 func NewVector() Vector {
-	return Vector{common.WeightsMetrics{make(common.Metrics), weights}}
+	return Vector{common.NewMetrics(weights, notDefined)}
 }
 
 func (v Vector) Validate() error {
@@ -147,11 +154,11 @@ func (v Vector) Parse(str string) error {
 	if strings.HasPrefix(strings.ToUpper(str), prefix) {
 		str = str[len(prefix):]
 	}
-	return v.WeightsMetrics.Parse(str)
+	return v.Metrics.Parse(str)
 }
 
 func (v Vector) String() string {
-	return prefix + v.WeightsMetrics.String()
+	return prefix + v.Metrics.String()
 }
 
 // weight functions


### PR DESCRIPTION
This diff enables us to parse undefined values. But it ignores them
(doesn't call `Set` if the parsed value is undefined). Also, doesn't print
undefined values in `String()`

So if we have a cvss v3 vector `v` set to `E:U`, calling
`v.Parse("E:X/RL:X/RC:C").String()` will produce `"E:U/RC:C"`

Also, made weights easier to use by removing weights default.

```
$ (go build ./... && go test ./...) >/dev/null && echo good good
good good
```