### PR TITLE
[cvss3] Better API for cvss3 vector

### DIFF
--- a/cvss3/score_test.go
+++ b/cvss3/score_test.go
@@ -78,8 +78,10 @@ func TestBaseScores(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %2d", i+1), func(t *testing.T) {
-			v := Vector{}
-			v.Parse(c.str)
+			v, err := VectorFromString(c.str)
+			if err != nil {
+				t.Errorf("parse error: %v", err)
+			}
 			if vbs := v.BaseScore(); vbs != c.baseScore {
 				t.Errorf("expected %.1f, got %.1f", c.baseScore, vbs)
 			}
@@ -109,8 +111,10 @@ func TestScores(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %2d", i+1), func(t *testing.T) {
-			v := Vector{}
-			v.Parse(c.str)
+			v, err := VectorFromString(c.str)
+			if err != nil {
+				t.Errorf("parse error: %v", err)
+			}
 			if vbs := v.BaseScore(); vbs != c.base {
 				t.Errorf("expected %.1f, got %.1f", c.base, vbs)
 			}

--- a/cvss3/temporal_metrics.go
+++ b/cvss3/temporal_metrics.go
@@ -106,12 +106,6 @@ const (
 var (
 	weightsReportConfidence = []float64{1.0, 1.0, 0.96, 0.92}
 	codeReportConfidence    = []string{"X", "C", "R", "U"}
-	mapReportConfidence     = map[string]ReportConfidence{
-		"X": ReportConfidenceNotdefined,
-		"C": ReportConfidenceConfirmed,
-		"R": ReportConfidenceReasonable,
-		"U": ReportConfidenceUnknown,
-	}
 )
 
 func (rc ReportConfidence) defined() bool {


### PR DESCRIPTION
calling v1.parse(str) could fail in the middle so some of the values
would change and some wouldn't. There would be no way to recover.

This way we separate this into first parsing the vectors on each own and
then doing merge (absorb or absorbDefined)
Absorb will absorb only the values in the new vector which are
actually defined and override them in the first vector.