### PR TITLE
[cpe2cve] Resolve a panic in cpe2cve

### DIFF
--- a/cmd/cpe2cve/cpe2cve.go
+++ b/cmd/cpe2cve/cpe2cve.go
@@ -121,14 +121,14 @@ func process(in <-chan []string, out chan<- []string, cache *cvefeed.Cache, cfg 
 			continue
 		}
 		cpeList := strings.Split(rec[cpesAt], cfg.inRecSep)
-		cpes := make([]*wfn.Attributes, len(cpeList))
-		for i, uri := range cpeList {
+		cpes := make([]*wfn.Attributes, 0, len(cpeList))
+		for _, uri := range cpeList {
 			attr, err := wfn.Parse(uri)
 			if err != nil {
 				glog.Errorf("couldn't parse uri %q: %v", uri, err)
 				continue
 			}
-			cpes[i] = attr
+			cpes = append(cpes, attr)
 		}
 		rec[cpesAt] = strings.Join(cpeList, cfg.outRecSep)
 		for _, matches := range cache.Get(cpes) {


### PR DESCRIPTION
When there's a cpe which cannot be parsed, there's a panic in the
matching phase.

Before fix:
```
$ echo asdf | go run ./cmd/cpe2cve -cpe 1 -cve 2 ~/dev/snyk_golang.json
E0704 10:53:24.927330   33013 cpe2cve.go:128] couldn't parse uri "asdf": wfn: unsupported format "asdf"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x1105194]

goroutine 52 [running]:
github.com/facebookincubator/nvdtools/cvefeed/nvdjson.(*node).MatchPlatform(0xc000311d10, 0x0, 0x0, 0x0)
	/Users/hrenic/Projects/gopath/src/github.com/facebookincubator/nvdtools/cvefeed/nvdjson/interfaces.go:130 +0x34
github.com/facebookincubator/nvdtools/cvefeed.matchLogicalTest(0xc00022d6b0, 0xc0000baa60, 0x1, 0x1, 0x118de00, 0xc000311d10, 0x1136f00, 0xc000240388)
	/Users/hrenic/Projects/gopath/src/github.com/facebookincubator/nvdtools/cvefeed/cvefeed.go:114 +0xee
github.com/facebookincubator/nvdtools/cvefeed.Match(0xc0000baa60, 0x1, 0x1, 0xc000097ca0, 0x1, 0x1, 0x0, 0xd0, 0x11480a0, 0x30, ...)
	/Users/hrenic/Projects/gopath/src/github.com/facebookincubator/nvdtools/cvefeed/cvefeed.go:88 +0x20b
github.com/facebookincubator/nvdtools/cvefeed.(*Cache).match(0xc0000aa080, 0xc0000baa60, 0x1, 0x1, 0xc0000981e0, 0x0, 0x39, 0x0)
	/Users/hrenic/Projects/gopath/src/github.com/facebookincubator/nvdtools/cvefeed/cvecache.go:230 +0x15c
github.com/facebookincubator/nvdtools/cvefeed.(*Cache).Get(0xc0000aa080, 0xc0000baa60, 0x1, 0x1, 0x1, 0xc0002f04f8, 0x4)
	/Users/hrenic/Projects/gopath/src/github.com/facebookincubator/nvdtools/cvefeed/cvecache.go:174 +0x475
main.process(0xc000322120, 0xc000322180, 0xc0000aa080, 0x1, 0x1, 0x2, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/hrenic/Projects/gopath/src/github.com/facebookincubator/nvdtools/cmd/cpe2cve/cpe2cve.go:134 +0x197
main.processInput.func1(0xc000322120, 0xc000322180, 0xc0000aa080, 0xc000324000, 0xc000114030, 0xc000114040)
	/Users/hrenic/Projects/gopath/src/github.com/facebookincubator/nvdtools/cmd/cpe2cve/cpe2cve.go:191 +0xcc
created by main.processInput
	/Users/hrenic/Projects/gopath/src/github.com/facebookincubator/nvdtools/cmd/cpe2cve/cpe2cve.go:190 +0x305
exit status 2
```

After fix:
```
$ echo asdf | go run ./cmd/cpe2cve -cpe 1 -cve 2 ~/dev/snyk_golang.json
E0704 10:52:32.184756   32670 cpe2cve.go:128] couldn't parse uri "asdf": wfn: unsupported format "asdf"
```