### PR TITLE
[providers] Make sure all providers fetch since last modification

### DIFF
--- a/providers/flexera/api/client.go
+++ b/providers/flexera/api/client.go
@@ -134,8 +134,8 @@ func (c Client) Fetch(identifier string) (*schema.Advisory, error) {
 func (c Client) fetchAdvisoryList(from, to int64, page int) (*schema.AdvisoryListResult, error) {
 	var list schema.AdvisoryListResult
 	params := map[string]interface{}{
-		"released__gte": from,
-		"released__lt":  to,
+		"modified__gte": from,
+		"modified__lt":  to,
 		"page":          page,
 		"page_size":     pageSize,
 	}
@@ -148,8 +148,8 @@ func (c Client) fetchAdvisoryList(from, to int64, page int) (*schema.AdvisoryLis
 func (c Client) getNumberOfAdvisories(from, to int64) (int, error) {
 	var list schema.AdvisoryListResult
 	params := map[string]interface{}{
-		"released__gte": from,
-		"released__lt":  to,
+		"modified__gte": from,
+		"modified__lt":  to,
 		"page_size":     1,
 	}
 	if err := c.query(advisoriesEndpoint, params, &list); err != nil {

--- a/providers/idefense/api/client.go
+++ b/providers/idefense/api/client.go
@@ -55,8 +55,9 @@ func (c Client) FetchAllVulnerabilities(since int64) (<-chan runner.Convertible,
 	sinceStr := time.Unix(since, 0).Format("2006-01-02T15:04:05.000Z")
 
 	result, err := c.queryVulnerabilities(map[string]interface{}{
-		"last_published.from": sinceStr,
-		"page_size":           0,
+		"last_modified.from":      sinceStr,
+		"last_modified.inclusive": "true",
+		"page_size":               0,
 	})
 	if err != nil {
 		return nil, err
@@ -79,9 +80,10 @@ func (c Client) FetchAllVulnerabilities(since int64) (<-chan runner.Convertible,
 		go func() {
 			defer wg.Done()
 			result, err := c.queryVulnerabilities(map[string]interface{}{
-				"last_published.from": sinceStr,
-				"page_size":           pageSize,
-				"page":                page,
+				"last_modified.from":      sinceStr,
+				"last_modified.inclusive": "true",
+				"page_size":               pageSize,
+				"page":                    page,
 			})
 			if err != nil {
 				log.Printf("failed to get page %d: %v", page, err)

--- a/providers/rbs/api/client.go
+++ b/providers/rbs/api/client.go
@@ -73,12 +73,10 @@ func (c *Client) FetchAllVulnerabilitiesAfterVulndbID(vulndbID int) (<-chan runn
 
 func (c *Client) FetchAllVulnerabilities(since int64) (<-chan runner.Convertible, error) {
 	from := time.Unix(since, 0)
-	getEndpoint := func() string {
+	return c.fetchAllVulnerabilities(func() string {
 		// we need to recalculate hours ago on each request, if the fetching takes more than an hour
-		u := fmt.Sprintf("find_by_time_full?hours_ago=%d", int(time.Since(from).Hours()))
-		return u
-	}
-	return c.fetchAllVulnerabilities(getEndpoint)
+		return fmt.Sprintf("find_by_time_full?hours_ago=%d", int(time.Since(from).Hours()))
+	})
 }
 
 func (c *Client) fetchAllVulnerabilities(getEndpoint func() string) (<-chan runner.Convertible, error) {


### PR DESCRIPTION
We want the -since flag to query the APIs and return a list of all vulns
which were modified (not published/released) since then.