### PR TITLE
[vulndb] Subdivide batches when inserting fails

### DIFF
--- a/vulndb/schema.sql
+++ b/vulndb/schema.sql
@@ -12,6 +12,10 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+CREATE DATABASE IF NOT EXISTS vulndb;
+
+USE vulndb;
+
 DROP TABLE IF EXISTS
 	`snooze`,
 	`custom_data`,


### PR DESCRIPTION
When we insert stuff into vendor_data, sometimes a batch can be to big
and won't insert. So instead, we just subdivide the batches into smaller
portions (until a batch size is 1) and try to insert those.

go test ./... works. Tested insert, works

also, move batch size from 10 to 100. 