### PR TITLE
Non-existent wfn attributes default to wfn.NA instead of wfn.Any.

### DIFF
--- a/cmd/cpe2cve/cpe2cve_test.go
+++ b/cmd/cpe2cve/cpe2cve_test.go
@@ -60,11 +60,11 @@ func TestProcessInput(t *testing.T) {
 			in: "1,2,3,cpe:/o:microsoft:windows_10:-::~~~~x64~+cpe:/a:adobe:flash_player:24.0.0.194,5,6,7,8,9,10",
 			out: [][]string{
 				{
-					"2|cpe:/o:microsoft:windows_10:-::~~~~x64~&cpe:/a:adobe:flash_player:24.0.0.194|5|6|7|CVE-2016-0165|cpe:/o:microsoft:windows_10:::~~~~x64~|8|9|10",
+					"2|cpe:/o:microsoft:windows_10:-::~~~~x64~&cpe:/a:adobe:flash_player:24.0.0.194|5|6|7|CVE-2016-0165|cpe:/o:microsoft:windows_10:-::~~~~x64~|8|9|10",
 				},
 				{
-					"2|cpe:/o:microsoft:windows_10:-::~~~~x64~&cpe:/a:adobe:flash_player:24.0.0.194|5|6|7|CVE-2666-1337|cpe:/o:microsoft:windows_10:::~~~~x64~&cpe:/a:adobe:flash_player:24.0.0.194|8|9|10",
-					"2|cpe:/o:microsoft:windows_10:-::~~~~x64~&cpe:/a:adobe:flash_player:24.0.0.194|5|6|7|CVE-2666-1337|cpe:/a:adobe:flash_player:24.0.0.194&cpe:/o:microsoft:windows_10:::~~~~x64~|8|9|10",
+					"2|cpe:/o:microsoft:windows_10:-::~~~~x64~&cpe:/a:adobe:flash_player:24.0.0.194|5|6|7|CVE-2666-1337|cpe:/o:microsoft:windows_10:-::~~~~x64~&cpe:/a:adobe:flash_player:24.0.0.194|8|9|10",
+					"2|cpe:/o:microsoft:windows_10:-::~~~~x64~&cpe:/a:adobe:flash_player:24.0.0.194|5|6|7|CVE-2666-1337|cpe:/a:adobe:flash_player:24.0.0.194&cpe:/o:microsoft:windows_10:-::~~~~x64~|8|9|10",
 				},
 			},
 		},
@@ -110,7 +110,7 @@ func TestProcessInput(t *testing.T) {
 						}
 					}
 					if !found {
-						t.Fatalf("got:\n%q\nexpected one of:%v", s, c.out)
+						t.Fatalf("got:\n%q\nexpected one of:\n%#v", s, c.out)
 					}
 				}
 			})

--- a/cmd/csv2cpe/csv2cpe.go
+++ b/cmd/csv2cpe/csv2cpe.go
@@ -159,7 +159,7 @@ func (acm *AttributeColumnMap) AddFlags(fs *flag.FlagSet) {
 // CPE returns a CPE by mapping cols to the configured column indices.
 func (acm *AttributeColumnMap) CPE(cols []string, lower bool) (string, error) {
 	var err error
-	var attr wfn.Attributes
+	attr := wfn.NewAttributesWithNA()
 
 	m := map[int]*string{
 		acm.Part:      &attr.Part,

--- a/cmd/csv2cpe/csv2cpe_test.go
+++ b/cmd/csv2cpe/csv2cpe_test.go
@@ -85,13 +85,19 @@ func TestProcessor(t *testing.T) {
 			[]string{"-cpe_product=1", "-cpe_version=2"},
 			NewIntSet(1, 2, 3),
 			"Foo\t1.0...\tdelet\ta\nbar\t2.0\tdelet\tb",
-			"a,cpe:/::foo:1.0\nb,cpe:/::bar:2.0\n",
+			"a,cpe:/-:-:foo:1.0:-:-:-\nb,cpe:/-:-:bar:2.0:-:-:-\n",
 		},
 		{
 			[]string{"-cpe_part=1", "-cpe_product=2", "-cpe_product=4"},
 			NewIntSet(1, 2, 3),
 			"a\tb\tc\n",
-			"cpe:/a\n",
+			"cpe:/a:-:-:-:-:-:-\n",
+		},
+		{
+			[]string{"-cpe_part=1", "-cpe_product=2", "-cpe_version=3"},
+			NewIntSet(1, 2, 3),
+			"a\tbash\t4.4\n",
+			"cpe:/a:-:bash:4.4:-:-:-\n",
 		},
 	}
 

--- a/cmd/rpm2cpe/rpm2cpe.go
+++ b/cmd/rpm2cpe/rpm2cpe.go
@@ -25,6 +25,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/facebookincubator/nvdtools/wfn"
+
 	"github.com/facebookincubator/nvdtools/cpeparse"
 )
 
@@ -126,8 +128,9 @@ func processRecord(fields []string, cfg config) ([]string, error) {
 	if cfg.rpmField > len(fields) {
 		return nil, fmt.Errorf("not enough fields (%d)", len(fields))
 	}
-	attr, err := cpeparse.FromRPMName(fields[cfg.rpmField-1])
-	if err != nil {
+	attr := wfn.NewAttributesWithNA()
+	attr.Vendor = wfn.Any
+	if err := cpeparse.FromRPMName(attr, fields[cfg.rpmField-1]); err != nil {
 		return nil, fmt.Errorf("couldn't parse RPM name from field %q: %v", fields[cfg.rpmField-1], err)
 	}
 	cpe := attr.BindToURI()

--- a/cmd/rpm2cpe/rpm2cpe_test.go
+++ b/cmd/rpm2cpe/rpm2cpe_test.go
@@ -59,8 +59,12 @@ func TestProcessRecord(t *testing.T) {
 		fail bool
 	}{
 		{"", "", true},
-		{"0,name-1.0-1.noarch.rpm", "name-1.0-1.noarch.rpm;cpe:/a::name:1.0:1", false},
-		{"0,name-1.0-1.i386.rpm,2,3,4,5,6", "name-1.0-1.i386.rpm;2;4;5;cpe:/a::name:1.0:1:~~~~i386~;6", false},
+		{"0,name-1.0-1.noarch.rpm", "name-1.0-1.noarch.rpm;cpe:/a::name:1.0:1:~-~-~-~~-:-", false},
+		{
+			"0,name-1.0-1.i386.rpm,2,3,4,5,6",
+			"name-1.0-1.i386.rpm;2;4;5;cpe:/a::name:1.0:1:~-~-~-~i386~-:-;6",
+			false,
+		},
 	}
 	cfg := config{
 		rpmField:    2,
@@ -83,7 +87,7 @@ func TestProcessRecord(t *testing.T) {
 		}
 		out := strings.Join(record, cfg.outFieldSep)
 		if c.out != out {
-			t.Errorf("line %q: expected %q, got %q", c.in, c.out, out)
+			t.Errorf("line %q:\nhave: %q\nwant: %q", c.in, c.out, out)
 		}
 	}
 }

--- a/cpeparse/rpmname.go
+++ b/cpeparse/rpmname.go
@@ -66,23 +66,22 @@ func FieldsFromRPMName(s string) (name, ver, rel, arch string, err error) {
 }
 
 // FromRPMName parses CPE name from RPM package name
-func FromRPMName(s string) (*wfn.Attributes, error) {
+func FromRPMName(attr *wfn.Attributes, s string) error {
 	var err error
 	name, ver, rel, arch, err := FieldsFromRPMName(s)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if name == wfn.Any {
-		return nil, fmt.Errorf("no name found in RPM name %q", s)
+		return fmt.Errorf("no name found in RPM name %q", s)
 	}
 	if ver == wfn.Any {
-		return nil, fmt.Errorf("no version found in RPM name %q", s)
+		return fmt.Errorf("no version found in RPM name %q", s)
 	}
-	return &wfn.Attributes{
-		Part:     "a", // TODO: figure out the way to properly detect os packages (linux_kernel or smth)
-		Product:  name,
-		Version:  ver,
-		Update:   rel,
-		TargetHW: arch,
-	}, nil
+	attr.Part = "a" // TODO: figure out the way to properly detect os packages (linux_kernel or smth)
+	attr.Product = name
+	attr.Version = ver
+	attr.Update = rel
+	attr.TargetHW = arch
+	return nil
 }

--- a/cpeparse/rpmname_test.go
+++ b/cpeparse/rpmname_test.go
@@ -14,7 +14,11 @@
 
 package cpeparse
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/facebookincubator/nvdtools/wfn"
+)
 
 func TestFromRPMName(t *testing.T) {
 	cases := []struct {
@@ -30,7 +34,8 @@ func TestFromRPMName(t *testing.T) {
 		{"NaMe-1.0-1.src.rpm", "cpe:2.3:a:*:name:1.0:1:*:*:*:*:*:*", false},
 	}
 	for _, c := range cases {
-		attr, err := FromRPMName(c.pkgName)
+		var attr wfn.Attributes
+		err := FromRPMName(&attr, c.pkgName)
 		if err != nil {
 			if !c.fail {
 				t.Errorf("%q: unexpected failure: %v", c.pkgName, err)
@@ -49,7 +54,8 @@ func TestFromRPMName(t *testing.T) {
 
 func BenchmarkFromRPMName(t *testing.B) {
 	for i := 0; i < t.N; i++ {
-		FromRPMName("NaMe-1.0-1.i386.rpm")
+		var attr wfn.Attributes
+		FromRPMName(&attr, "NaMe-1.0-1.i386.rpm")
 	}
 }
 

--- a/wfn/uri.go
+++ b/wfn/uri.go
@@ -37,10 +37,18 @@ func (a Attributes) BindToURI() string {
 			continue
 		}
 		edParts := make([]string, 5)
+		allNAs := true
 		for i, v2 := range []string{a.Edition, a.SWEdition, a.TargetSW, a.TargetHW, a.Other} {
 			edParts[i] = bindValueURI(v2)
+			if edParts[i] != "-" {
+				allNAs = false
+			}
 		}
-		parts = append(parts, pack(edParts))
+		if allNAs {
+			parts = append(parts, "-")
+		} else {
+			parts = append(parts, pack(edParts))
+		}
 	}
 	// empty elements at the end of the URI should be omitted
 	for i := len(parts) - 1; i >= 0; i-- {
@@ -125,6 +133,12 @@ func pack(ss []string) string {
 // - unquoted special characters are mapped to their special forms.
 func bindValueURI(s string) string {
 	var out []byte
+	switch s {
+	case NA:
+		return "-"
+	case Any:
+		return ""
+	}
 	for i := 0; i < len(s); i++ {
 		b := byte(s[i])
 		if b >= '0' && b <= '9' || b >= 'a' && b <= 'z' || b >= 'A' && b <= 'Z' || b == '_' {

--- a/wfn/wfn.go
+++ b/wfn/wfn.go
@@ -33,21 +33,6 @@ const (
 	NA  = "-"
 )
 
-// Attributes defines the WFN Data Model Attributes.
-type Attributes struct {
-	Part      string
-	Vendor    string
-	Product   string
-	Version   string
-	Update    string
-	Edition   string
-	SWEdition string
-	TargetSW  string
-	TargetHW  string
-	Other     string
-	Language  string
-}
-
 const (
 	uriPrefix = "cpe:/"
 	fsbPrefix = "cpe:2.3:"
@@ -66,6 +51,47 @@ func Parse(s string) (*Attributes, error) {
 		}
 	}
 	return nil, fmt.Errorf("wfn: unsupported format %q", s)
+}
+
+// Attributes defines the WFN Data Model Attributes.
+type Attributes struct {
+	Part      string
+	Vendor    string
+	Product   string
+	Version   string
+	Update    string
+	Edition   string
+	SWEdition string
+	TargetSW  string
+	TargetHW  string
+	Other     string
+	Language  string
+}
+
+// NewAttributesWithNA allocates Attributes object with all fields initialized to NA logical value
+func NewAttributesWithNA() *Attributes {
+	return newAttributes(NA)
+}
+
+// NewAttributesWithAny allocates Attributes object with all fields initialized to Any logical value
+func NewAttributesWithAny() *Attributes {
+	return newAttributes(Any)
+}
+
+func newAttributes(defaultValue string) *Attributes {
+	return &Attributes{
+		Part:      defaultValue,
+		Vendor:    defaultValue,
+		Product:   defaultValue,
+		Version:   defaultValue,
+		Update:    defaultValue,
+		Edition:   defaultValue,
+		SWEdition: defaultValue,
+		TargetSW:  defaultValue,
+		TargetHW:  defaultValue,
+		Other:     defaultValue,
+		Language:  defaultValue,
+	}
 }
 
 // WFNize transforms a string into CPE23-NAME compliant avstring value.


### PR DESCRIPTION
wfn.Any happends to be "", which is zero-value for a string.
We rely on this all over the place, including in csv2cpe and rpm2cpe tools,
which is not correct in the latter cases, it should be wfn.NA instead.