### PR TITLE
Add RedHat feed to the providers

### DIFF
--- a/cmd/redhat2nvd/redhat2nvd.go
+++ b/cmd/redhat2nvd/redhat2nvd.go
@@ -1,0 +1,66 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/facebookincubator/nvdtools/providers/lib/runner"
+	"github.com/facebookincubator/nvdtools/providers/redhat/api"
+	"github.com/facebookincubator/nvdtools/providers/redhat/schema"
+)
+
+const (
+	baseURL   = "https://access.redhat.com/labs/securitydataapi"
+	userAgent = "redhat2nvd"
+)
+
+func Read(r io.Reader, c chan runner.Convertible) error {
+	var vulns map[string]*schema.CVE
+	if err := json.NewDecoder(r).Decode(&vulns); err != nil {
+		return fmt.Errorf("can't decode into vulns: %v", err)
+	}
+
+	for _, vuln := range vulns {
+		c <- vuln
+	}
+
+	return nil
+}
+
+func FetchSince(baseURL, userAgent string, since int64) (<-chan runner.Convertible, error) {
+	client := api.NewClient(baseURL, userAgent)
+	return client.FetchAllCVEs(since)
+}
+
+func main() {
+	r := runner.Runner{
+		Config: runner.Config{
+			BaseURL:   baseURL,
+			UserAgent: userAgent,
+		},
+		FetchSince: FetchSince,
+		Read:       Read,
+	}
+
+	if err := r.Run(); err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
+}

--- a/providers/redhat/api/client.go
+++ b/providers/redhat/api/client.go
@@ -1,0 +1,142 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/facebookincubator/nvdtools/providers/lib/client"
+	"github.com/facebookincubator/nvdtools/providers/lib/runner"
+	"github.com/facebookincubator/nvdtools/providers/redhat/schema"
+)
+
+const (
+	perPage = 50
+)
+
+// Client struct
+type Client struct {
+	client.Client
+	baseURL   string
+	userAgent string
+}
+
+// NewClient creates an object which is used to query the iDefense API
+func NewClient(baseURL, userAgent string) Client {
+	c := client.Default()
+	// 10 requests per second
+	c = client.Throttle(c, time.Second, 10)
+	// retry up to 5 times given statuses, 3 second delay between requests
+	c = client.Retry(c, 5, 3*time.Second, http.StatusTooManyRequests, http.StatusGatewayTimeout)
+	return Client{
+		Client:    c,
+		baseURL:   baseURL,
+		userAgent: userAgent,
+	}
+}
+
+// FetchAll will fetch all vulnerabilities
+func (c *Client) FetchAllCVEs(since int64) (<-chan runner.Convertible, error) {
+	output := make(chan runner.Convertible)
+	wg := sync.WaitGroup{}
+
+	for page := range c.fetchAllPages(since) {
+		for _, cveItem := range *page {
+			wg.Add(1)
+			go func(cveid string) {
+				defer wg.Done()
+				log.Printf("\tfetching cve %s", cveid)
+				cve, err := c.fetchCVE(cveid)
+				if err != nil {
+					log.Printf("error while fetching cve %s: %v", cveid, err)
+					return
+				}
+				output <- cve
+			}(cveItem.CVE)
+		}
+	}
+
+	go func() {
+		wg.Wait()
+		close(output)
+	}()
+
+	return output, nil
+}
+
+func (c *Client) fetchCVE(cveid string) (*schema.CVE, error) {
+	resp, err := c.queryPath(fmt.Sprintf("/cve/%s.json", cveid))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch from feed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var cve schema.CVE
+	if err := json.NewDecoder(resp.Body).Decode(&cve); err != nil {
+		return nil, fmt.Errorf("failed to decode cve response into a cve: %v", err)
+	}
+
+	return &cve, nil
+}
+
+func (c *Client) fetchAllPages(since int64) <-chan *schema.CVEList {
+	output := make(chan *schema.CVEList)
+	go func() {
+		defer close(output)
+		for page := 1; ; page++ {
+			log.Printf("fetching page %d", page)
+			if list, err := c.fetchListPage(since, page); err == nil {
+				output <- list
+				if len(*list) < perPage {
+					break
+				}
+			} else {
+				log.Printf("can't fecth page %d: %v", page, err)
+				break
+			}
+		}
+	}()
+	return output
+}
+
+func (c *Client) fetchListPage(since int64, page int) (*schema.CVEList, error) {
+	params := url.Values{}
+	params.Add("per_page", strconv.Itoa(perPage))
+	params.Add("page", strconv.Itoa(page))
+	params.Add("after", time.Unix(since, 0).Format("2006-01-02")) // YYYY-MM-DD
+
+	resp, err := c.queryPath("/cve.json?" + params.Encode())
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch cve list: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var cveList schema.CVEList
+	if err := json.NewDecoder(resp.Body).Decode(&cveList); err != nil {
+		return nil, fmt.Errorf("failed to decode response into a list of cves: %v", err)
+	}
+	return &cveList, nil
+}
+
+func (c *Client) queryPath(path string) (*http.Response, error) {
+	return client.Get(c.Client, c.baseURL+path, http.Header{"User-Agent": {c.userAgent}})
+}

--- a/providers/redhat/schema/convert.go
+++ b/providers/redhat/schema/convert.go
@@ -1,0 +1,220 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	nvd "github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
+)
+
+const (
+	cveVersion = "4.0"
+)
+
+func (cve *CVE) Convert() (*nvd.NVDCVEFeedJSON10DefCVEItem, error) {
+	publishedDate, err := convertTime(cve.PublicDate)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert published date: %v", err)
+	}
+	configurations, err := cve.newConfigurations()
+	if err != nil {
+		return nil, fmt.Errorf("unable to construct configurations: %v", err)
+	}
+	impact, err := cve.newImpact()
+	if err != nil {
+		return nil, fmt.Errorf("unable to construct impact: %v", err)
+	}
+
+	item := nvd.NVDCVEFeedJSON10DefCVEItem{
+		CVE: &nvd.CVEJSON40{
+			CVEDataMeta: &nvd.CVEJSON40CVEDataMeta{
+				ID:       cve.ID(),
+				ASSIGNER: "redhat",
+			},
+			DataFormat:  "MITRE",
+			DataType:    "CVE",
+			DataVersion: cveVersion,
+			Description: &nvd.CVEJSON40Description{
+				DescriptionData: []*nvd.CVEJSON40LangString{
+					{
+						Lang:  "en",
+						Value: strings.Join(cve.Details, "\n"),
+					},
+				},
+			},
+			Problemtype: cve.newProblemType(),
+			References:  cve.newReferences(),
+		},
+		Configurations: configurations,
+		Impact:         impact,
+		PublishedDate:  publishedDate,
+	}
+
+	return &item, nil
+}
+
+func (cve *CVE) ID() string {
+	return cve.Name
+}
+
+func (cve *CVE) newProblemType() *nvd.CVEJSON40Problemtype {
+	cwes := findCWEs(cve.CWE)
+	if len(cwes) == 0 {
+		return nil
+	}
+	data := make([]*nvd.CVEJSON40ProblemtypeProblemtypeData, len(cwes))
+	for i, cwe := range cwes {
+		data[i] = &nvd.CVEJSON40ProblemtypeProblemtypeData{
+			Description: []*nvd.CVEJSON40LangString{
+				{Lang: "en", Value: cwe},
+			},
+		}
+	}
+
+	return &nvd.CVEJSON40Problemtype{ProblemtypeData: data}
+}
+
+func (cve *CVE) newReferences() *nvd.CVEJSON40References {
+	if len(cve.References) == 0 {
+		return nil
+	}
+
+	referenceData := make([]*nvd.CVEJSON40Reference, len(cve.References))
+	for i, ref := range cve.References {
+		referenceData[i] = &nvd.CVEJSON40Reference{URL: ref}
+	}
+
+	return &nvd.CVEJSON40References{ReferenceData: referenceData}
+}
+
+func (cve *CVE) newImpact() (*nvd.NVDCVEFeedJSON10DefImpact, error) {
+	if cve.CVSS == nil && cve.CVSS3 == nil {
+		return nil, fmt.Errorf("cvss v2 nor cvss v3 is set in the cve")
+	}
+
+	impact := nvd.NVDCVEFeedJSON10DefImpact{}
+
+	if cve.CVSS != nil {
+		score, err := strconv.ParseFloat(cve.CVSS.BaseScore, 64)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse cvss v2 base score: %v", err)
+		}
+		impact.BaseMetricV2 = &nvd.NVDCVEFeedJSON10DefImpactBaseMetricV2{
+			CVSSV2: &nvd.CVSSV20{
+				BaseScore:    score,
+				VectorString: cve.CVSS.Vector,
+			},
+		}
+	}
+
+	if cve.CVSS3 != nil {
+		score, err := strconv.ParseFloat(cve.CVSS3.BaseScore, 64)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse cvss v3 base score: %v", err)
+		}
+		impact.BaseMetricV3 = &nvd.NVDCVEFeedJSON10DefImpactBaseMetricV3{
+			CVSSV3: &nvd.CVSSV30{
+				BaseScore:    score,
+				VectorString: cve.CVSS3.Vector,
+			},
+		}
+	}
+
+	return &impact, nil
+}
+
+// CPEs configuration, AKA the tricky part
+
+func (cve *CVE) newConfigurations() (*nvd.NVDCVEFeedJSON10DefConfigurations, error) {
+	nodes := make([]*nvd.NVDCVEFeedJSON10DefNode, len(cve.AffectedRelease)+len(cve.PackageState))
+
+	var err error
+
+	for i, ar := range cve.AffectedRelease {
+		if nodes[i], err = ar.createNode(); err != nil {
+			return nil, fmt.Errorf("can't create node for affected release %d: %v", i, err)
+		}
+	}
+
+	offset := len(cve.AffectedRelease)
+	for i, ps := range cve.PackageState {
+		if nodes[i+offset], err = ps.createNode(); err != nil {
+			return nil, fmt.Errorf("can't create node for package state %d: %v", i, err)
+		}
+	}
+
+	conf := nvd.NVDCVEFeedJSON10DefConfigurations{
+		CVEDataVersion: cveVersion,
+		Nodes:          nodes,
+	}
+
+	return &conf, nil
+}
+
+func (ar *AffectedRelease) createNode() (*nvd.NVDCVEFeedJSON10DefNode, error) {
+	node := nvd.NVDCVEFeedJSON10DefNode{
+		Operator: "AND",
+		CPEMatch: []*nvd.NVDCVEFeedJSON10DefCPEMatch{
+			{
+				Cpe22Uri:   ar.CPE,
+				Vulnerable: false,
+			},
+		},
+	}
+
+	if ar.Package != "" {
+		pkgAttrs, err := package2wfn(ar.Package)
+		if err != nil {
+			return nil, fmt.Errorf("can't create wfn from package: %v", err)
+		}
+
+		node.CPEMatch = append(node.CPEMatch, &nvd.NVDCVEFeedJSON10DefCPEMatch{
+			Cpe22Uri:   pkgAttrs.BindToURI(),
+			Cpe23Uri:   pkgAttrs.BindToFmtString(),
+			Vulnerable: false,
+		})
+	}
+
+	return &node, nil
+}
+
+func (ps *PackageState) createNode() (*nvd.NVDCVEFeedJSON10DefNode, error) {
+	pkgAttrs, err := packageName2wfn(ps.PackageName)
+	if err != nil {
+		return nil, fmt.Errorf("can't create wfn from package name: %v", err)
+	}
+
+	node := nvd.NVDCVEFeedJSON10DefNode{
+		Operator: "AND",
+		CPEMatch: []*nvd.NVDCVEFeedJSON10DefCPEMatch{
+			// package
+			{
+				Cpe22Uri:   pkgAttrs.BindToURI(),
+				Cpe23Uri:   pkgAttrs.BindToFmtString(),
+				Vulnerable: IsVulnerable(ps.FixState),
+			},
+			// distribution
+			{
+				Cpe22Uri:   ps.CPE,
+				Vulnerable: false,
+			},
+		},
+	}
+
+	return &node, nil
+}

--- a/providers/redhat/schema/convertutils.go
+++ b/providers/redhat/schema/convertutils.go
@@ -1,0 +1,88 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	nvd "github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
+	"github.com/facebookincubator/nvdtools/rpm"
+	"github.com/facebookincubator/nvdtools/wfn"
+)
+
+const (
+	timeLayout = "2006-01-02T15:04:05"
+)
+
+var (
+	// cwe regex to match CWEs
+	cweRegex = regexp.MustCompile("CWE-[0-9]+")
+)
+
+func convertTime(redhatTime string) (string, error) {
+	t, err := time.Parse(timeLayout, redhatTime)
+	if err != nil { // should be parsable
+		log.Printf("unable to parse time: %v", err)
+		return redhatTime, err
+	}
+	return t.Format(nvd.TimeLayout), nil
+}
+
+func findCWEs(s string) []string {
+	return cweRegex.FindAllString(s, -1)
+}
+
+func IsVulnerable(fixState string) bool {
+	// $ jq 'to_entries | .[].value.package_state' redhat.json | grep fix_state | sort -u
+	// "fix_state": "Affected",
+	// "fix_state": "Fix deferred",
+	// "fix_state": "New",
+	// "fix_state": "Not affected",
+	// "fix_state": "Out of support scope",
+	// "fix_state": "Under investigation",
+	// "fix_state": "Will not fix",
+
+	switch strings.TrimSpace(strings.ToLower(fixState)) {
+	case "affected", "fix deferred", "new", "out of support scope", "will not fix":
+		return true
+	case "not affected", "under investigation":
+		return false
+	default:
+		log.Printf("unknown fix state: %q", fixState)
+		return false
+	}
+}
+
+func packageName2wfn(packageName string) (*wfn.Attributes, error) {
+	product, err := wfn.WFNize(packageName)
+	if err != nil {
+		return nil, fmt.Errorf("can't wfnize package name %q: %v", packageName, err)
+	}
+	attrs := wfn.Attributes{
+		Part:    "a",
+		Product: product,
+	}
+	return &attrs, nil
+}
+
+func package2wfn(pkg string) (*wfn.Attributes, error) {
+	attrs := wfn.NewAttributesWithAny()
+	err := rpm.ToWFN(attrs, pkg+".src") // add release .src so it parses correctly
+	return attrs, err
+}

--- a/providers/redhat/schema/schema.go
+++ b/providers/redhat/schema/schema.go
@@ -1,0 +1,124 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// based on this specification
+// https://access.redhat.com/documentation/en-us/red_hat_security_data_api/1.0/html-single/red_hat_security_data_api/index#cve_format
+
+type CVEList []struct {
+	CVE string `json:"cve`
+	// don't need the rest
+}
+
+type CVE struct {
+	Name           string `json:"name,omitempty"`
+	ThreatSeverity string `json:"threat_severity,omitempty,omitempty"`
+	PublicDate     string `json:"public_date,omitempty"`
+	Bugzilla       *struct {
+		Description string `json:"description,omitempty"`
+		ID          string `json:"id,omitempty"`
+		URL         string `json:"url,omitempty"`
+	} `json:"bugzilla,omitempty"`
+	CVSS *struct {
+		BaseScore string `json:"cvss_base_score,omitempty"`
+		Vector    string `json:"cvss_scoring_vector,omitempty"`
+		Status    string `json:"status,omitempty"`
+	} `json:"CVSS,omitempty"`
+	CVSS3 *struct {
+		BaseScore string `json:"cvss3_base_score,omitempty"`
+		Vector    string `json:"cvss3_scoring_vector,omitempty"`
+		Status    string `json:"status,omitempty"`
+	} `json:"CVSS3,omitempty"`
+	CWE             string   `json:"cwe,omitempty"`
+	Details         []string `json:"details,omitempty"`
+	Statement       string   `json:"statement,omitempty"`
+	References      []string `json:"references,omitempty"`
+	Acknowledgement string   `json:"acknowledgement,omitempty"`
+	Mitigation      string   `json:"mitigation,omitempty"`
+	UpstreamFix     string   `json:"upstream_fix,omitempty"`
+
+	// redhat uses a single object insted of an array when there's a single instance of that entity
+	// that's why we need to do it manually
+	// the types of these are just helper types
+
+	AffectedRelease AffectedReleases `json:"affected_release,omitempty"`
+	PackageState    PackageStates    `json:"package_state,omittempty"`
+}
+
+type AffectedRelease struct {
+	ProductName string `json:"product_name,omitempty"`
+	ReleaseDate string `json:"release_date,omitempty"`
+	Advisory    string `json:"advisory,omitempty"`
+	Package     string `json:"package,omitempty"`
+	CPE         string `json:"cpe,omitempty"`
+}
+
+type PackageState struct {
+	ProductName string `json:"product_name,omitempty"`
+	FixState    string `json:"fix_state,omitempty"`
+	PackageName string `json:"package_name,omitempty"`
+	CPE         string `json:"cpe,omitempty"`
+}
+
+// // functions bellow are used to "fix" redhat feed
+// // for some parts of the struct, they can either send an object X, or an array of X's when there's multiple of those
+// // I try to first decode it as an array. If that fails, try to decode it as an single entity.
+
+// these implement the UnmarshalJSON function, which gets called when we do unmarshal or decode
+
+type AffectedReleases []*AffectedRelease
+
+func (ars *AffectedReleases) UnmarshalJSON(b []byte) error {
+	// try to parse it as an array
+	var array []*AffectedRelease
+	if err := json.Unmarshal(b, &array); err == nil {
+		*ars = array
+		return nil
+	}
+
+	// try to parse it as a single object
+	var object AffectedRelease
+	if err := json.Unmarshal(b, &object); err == nil {
+		*ars = []*AffectedRelease{&object}
+		return nil
+	}
+
+	return fmt.Errorf("unable to decode affected release as an array nor as a single object")
+}
+
+type PackageStates []*PackageState
+
+func (pss *PackageStates) UnmarshalJSON(b []byte) error {
+	// try to parse it as an array
+	var array []*PackageState
+	if err := json.Unmarshal(b, &array); err == nil {
+		*pss = array
+		return nil
+	}
+
+	// try to parse it as a single object
+	var object PackageState
+	if err := json.Unmarshal(b, &object); err == nil {
+		*pss = []*PackageState{&object}
+		return nil
+	}
+
+	return fmt.Errorf("unable to decode package state as an array nor as a single object")
+}


### PR DESCRIPTION
This diff adds the publicly available RedHat feed as one possible
provider.

Test:
Using the already built tool, I ran this
```
go run ./cmd/redhat2nvd -download -since 24h > redhat.json
go run ./cmd/redhat2nvd -convert < redhat.json > nvd.json
```

redhat.json:	https://pastebin.com/hh9JHvs2
nvd.json:	https://pastebin.com/uRCvTSpa