### PR TITLE
[cpe2cve] Matching fix

### DIFF
--- a/cvefeed/nvd/match_cpe.go
+++ b/cvefeed/nvd/match_cpe.go
@@ -66,7 +66,7 @@ func cpeMatcher(nvdMatch *schema.NVDCVEFeedJSON10DefCPEMatch) (wfn.Matcher, erro
 // Match is part of the Matcher interface
 func (cm *cpeMatch) Match(attrs []*wfn.Attributes, requireVersion bool) (matches []*wfn.Attributes) {
 	for _, attr := range attrs {
-		if cm.match(attr, requireVersion) == cm.vulnerable {
+		if cm.match(attr, requireVersion) {
 			matches = append(matches, attr)
 		}
 	}


### PR DESCRIPTION
Vulnerable flag in cpe match means whether or not the product in
configuration is vulnerable to some cve. It's not the same as Negate
operator.

go test ./...
ran cpe2cve with previously false positive input, not outputed anymore