### PR TITLE
[flog] Add flog.AddFlags to init

### DIFF
--- a/cmd/cpe2cve/cpe2cve.go
+++ b/cmd/cpe2cve/cpe2cve.go
@@ -28,10 +28,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/cvefeed"
 	"github.com/facebookincubator/nvdtools/stats"
 	"github.com/facebookincubator/nvdtools/wfn"
-	"github.com/facebookincubator/flog"
 )
 
 func processAll(in <-chan []string, out chan<- []string, caches map[string]*cvefeed.Cache, cfg config, nlines *uint64) {
@@ -176,6 +176,8 @@ func processInput(in io.Reader, out io.Writer, caches map[string]*cvefeed.Cache,
 }
 
 func init() {
+	flog.AddFlags(flag.CommandLine, nil)
+	stats.AddFlags()
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: %s [flags] nvd_feed.xml.gz...\n", path.Base(os.Args[0]))
 		fmt.Fprintf(os.Stderr, "flags:\n")
@@ -196,7 +198,6 @@ func main() {
 func Main() int {
 	var cfg config
 	cfg.addFlags()
-	stats.AddFlags()
 	provider := flag.String("provider", "", "feed provider. used as a provider name for the feeds passed in through the command line")
 	cfgFile := flag.String("config", "", "path to a config file (JSON or TOML); see usage to see how it's configured (pass -v=1 flag for verbose help). Mutually exclusive with command line flags => when used, other flags are ignored")
 	flag.Parse()

--- a/cmd/nvdsync/main.go
+++ b/cmd/nvdsync/main.go
@@ -22,11 +22,12 @@ import (
 	"os"
 	"time"
 
-	"github.com/facebookincubator/nvdtools/providers/nvd"
 	"github.com/facebookincubator/flog"
+	"github.com/facebookincubator/nvdtools/providers/nvd"
 )
 
 func init() {
+	flog.AddFlags(flag.CommandLine, nil)
 	flag.Set("logtostderr", "true")
 }
 

--- a/cmd/rustsec2nvd/rustsec2nvd.go
+++ b/cmd/rustsec2nvd/rustsec2nvd.go
@@ -16,12 +16,17 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
 
-	"github.com/facebookincubator/nvdtools/providers/rustsec"
 	"github.com/facebookincubator/flog"
+	"github.com/facebookincubator/nvdtools/providers/rustsec"
 )
+
+func init() {
+	flog.AddFlags(flag.CommandLine, nil)
+}
 
 func main() {
 	if len(os.Args) != 2 {

--- a/cvefeed/cvecache.go
+++ b/cvefeed/cvecache.go
@@ -19,8 +19,8 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/facebookincubator/nvdtools/wfn"
 	"github.com/facebookincubator/flog"
+	"github.com/facebookincubator/nvdtools/wfn"
 )
 
 const cacheEvictPercentage = 0.1 // every eviction cycle invalidates this part of cache size at once

--- a/providers/nvd/cve.go
+++ b/providers/nvd/cve.go
@@ -33,8 +33,8 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/facebookincubator/nvdtools/providers/lib/download"
 	"github.com/facebookincubator/flog"
+	"github.com/facebookincubator/nvdtools/providers/lib/download"
 )
 
 // CVE defines the CVE data feed for synchronization.


### PR DESCRIPTION
it wasn't previously added so some binaries lost their -v flag (cpe2cve)

go test ./... go build ./...