### PR TITLE
Make default attribute value for CPE generation configurable.

### DIFF
--- a/cmd/csv2cpe/csv2cpe_test.go
+++ b/cmd/csv2cpe/csv2cpe_test.go
@@ -78,26 +78,37 @@ func TestProcessor(t *testing.T) {
 	cases := []struct {
 		flags []string
 		skips IntSet
+		na    bool
 		in    string
 		out   string
 	}{
 		{
 			[]string{"-cpe_product=1", "-cpe_version=2"},
 			NewIntSet(1, 2, 3),
+			true,
 			"Foo\t1.0...\tdelet\ta\nbar\t2.0\tdelet\tb",
 			"a,cpe:/-:-:foo:1.0:-:-:-\nb,cpe:/-:-:bar:2.0:-:-:-\n",
 		},
 		{
 			[]string{"-cpe_part=1", "-cpe_product=2", "-cpe_product=4"},
 			NewIntSet(1, 2, 3),
+			true,
 			"a\tb\tc\n",
 			"cpe:/a:-:-:-:-:-:-\n",
 		},
 		{
 			[]string{"-cpe_part=1", "-cpe_product=2", "-cpe_version=3"},
 			NewIntSet(1, 2, 3),
+			true,
 			"a\tbash\t4.4\n",
 			"cpe:/a:-:bash:4.4:-:-:-\n",
+		},
+		{
+			[]string{"-cpe_part=1", "-cpe_product=2", "-cpe_version=3"},
+			NewIntSet(1, 2, 3),
+			false,
+			"a\tbash\t4.4\n",
+			"cpe:/a::bash:4.4\n",
 		},
 	}
 
@@ -121,6 +132,7 @@ func TestProcessor(t *testing.T) {
 				CPEToLower:        true,
 				CPEOutputColumn:   2,
 				EraseInputColumns: c.skips,
+				DefaultNA:         c.na,
 			}
 
 			stdin.Write([]byte(c.in))

--- a/cmd/rpm2cpe/rpm2cpe_test.go
+++ b/cmd/rpm2cpe/rpm2cpe_test.go
@@ -54,16 +54,16 @@ func TestSkipFields(t *testing.T) {
 
 func TestProcessRecord(t *testing.T) {
 	cases := []struct {
-		in   string
-		out  string
-		fail bool
+		in, out   string
+		defaultNA bool
+		fail      bool
 	}{
-		{"", "", true},
-		{"0,name-1.0-1.noarch.rpm", "name-1.0-1.noarch.rpm;cpe:/a::name:1.0:1:~-~-~-~~-:-", false},
+		{"", "", false, true},
+		{"0,name-1.0-1.noarch.rpm", "name-1.0-1.noarch.rpm;cpe:/a::name:1.0:1:~-~-~-~~-:-", true, false},
 		{
-			"0,name-1.0-1.i386.rpm,2,3,4,5,6",
-			"name-1.0-1.i386.rpm;2;4;5;cpe:/a::name:1.0:1:~-~-~-~i386~-:-;6",
-			false,
+			in:        "0,name-1.0-1.i386.rpm,2,3,4,5,6",
+			out:       "name-1.0-1.i386.rpm;2;4;5;cpe:/a::name:1.0:1:~-~-~-~i386~-:-;6",
+			defaultNA: true,
 		},
 	}
 	cfg := config{
@@ -74,6 +74,7 @@ func TestProcessRecord(t *testing.T) {
 		skip:        fieldsToSkip(map[int]struct{}{0: {}, 3: {}}),
 	}
 	for _, c := range cases {
+		cfg.defaultNA = c.defaultNA
 		record, err := processRecord(strings.Split(c.in, cfg.inFieldSep), cfg)
 		if err != nil {
 			if !c.fail {


### PR DESCRIPTION
Basically, add an `-na` option to both rpm2cpe and csv2cpe tools;
when set, the default value is N/A; otherwise they stick to ANY.