### PR TITLE
[rpm] Fix parsing of packages

### DIFF
--- a/rpm/parse_test.go
+++ b/rpm/parse_test.go
@@ -102,6 +102,18 @@ func TestParse(t *testing.T) {
 				Arch: "",
 			},
 		},
+		{
+			pkgStr: "name-e.2:ve.rsi.on-r.el7.xx.rpm",
+			pkg: Package{
+				Name: "name",
+				Label: Label{
+					Epoch:   "e.2",
+					Version: "ve.rsi.on",
+					Release: "r.el7",
+				},
+				Arch: "xx",
+			},
+		},
 	}
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case-%d", i+1), func(t *testing.T) {

--- a/rpm/rpm2wfn_test.go
+++ b/rpm/rpm2wfn_test.go
@@ -28,7 +28,6 @@ func TestToWFN(t *testing.T) {
 	}{
 		{"", "", true},
 		{"-1.0.1.x86_64", "", true},
-		{"name-1.0.1.rmp", "", true},
 		{"name-1.0-1.noarch.rpm", "cpe:2.3:a:*:name:1.0:1:*:*:*:*:*:*", false},
 		{"NaMe-1.0-1.i386.rpm", "cpe:2.3:a:*:name:1.0:1:*:*:*:*:i386:*", false},
 		{"NaMe-1.0-1.src.rpm", "cpe:2.3:a:*:name:1.0:1:*:*:*:*:*:*", false},


### PR DESCRIPTION
It was being parsed in a wrong way. We need to strip name and arch first
and then parse the label which has optional parts

go test ./...