### PR TITLE
[rpm] Create rpm checker interface

### DIFF
--- a/rpm/checker.go
+++ b/rpm/checker.go
@@ -1,0 +1,77 @@
+package rpm
+
+import (
+	"fmt"
+
+	"github.com/facebookincubator/nvdtools/wfn"
+)
+
+// Checker knows how to verify whether some package has been fixed or not
+type Checker interface {
+	// Check should return whether a given package on distribution is fixed for some CVE
+	Check(pkg *Package, distro *wfn.Attributes, cve string) bool
+}
+
+// CheckAny returns a Checker which will return true if any of the underlying checkers returns true
+func CheckAny(chks ...Checker) Checker {
+	return anyChecker(chks)
+}
+
+type anyChecker []Checker
+
+// Check is part of the Checker interface
+func (c anyChecker) Check(pkg *Package, distro *wfn.Attributes, cve string) bool {
+	for _, chk := range c {
+		if chk.Check(pkg, distro, cve) {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckAll returns a Checker which will return true if all of the underlying checkers returns true
+func CheckAll(chks ...Checker) Checker {
+	return allChecker(chks)
+}
+
+type allChecker []Checker
+
+// Check is part of the Checker interface
+func (c allChecker) Check(pkg *Package, distro *wfn.Attributes, cve string) bool {
+	if len(c) == 0 {
+		return false
+	}
+	for _, chk := range c {
+		if !chk.Check(pkg, distro, cve) {
+			return false
+		}
+	}
+	return true
+}
+
+// MapChecker implements the Checker interface
+// calls the checker which is mapped to checked CVE
+type MapChecker map[string]Checker // CVE -> Checker
+
+// Check is part of the Checker interface
+func (c MapChecker) Check(pkg *Package, distro *wfn.Attributes, cve string) bool {
+	if chk, ok := c[cve]; ok {
+		return chk.Check(pkg, distro, cve)
+	}
+	return false
+}
+
+// Check will parse package and distro and call given checker to return
+func Check(chk Checker, pkg, distro, cve string) (bool, error) {
+	p, err := Parse(pkg)
+	if err != nil {
+		return false, fmt.Errorf("can't parse package %q: %v", pkg, err)
+	}
+
+	d, err := wfn.Parse(distro)
+	if err != nil {
+		return false, fmt.Errorf("can't parse distro cpe %q: %v", distro, err)
+	}
+
+	return chk.Check(p, d, cve), nil
+}


### PR DESCRIPTION
The goal of this interface is to answer the question: is some package
fixed for the given CVE on some distribution.

Next diffs will implement this checker for the redhat feed.