### PR TITLE
[redhat] Implement a binary to filter out fixed packages based on the

### DIFF
--- a/cmd/redhat_filter/main.go
+++ b/cmd/redhat_filter/main.go
@@ -1,0 +1,130 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/facebookincubator/flog"
+	"github.com/facebookincubator/nvdtools/providers/redhat"
+	"github.com/facebookincubator/nvdtools/rpm"
+)
+
+func main() {
+	var cfg config
+	cfg.addFlags()
+	flog.AddFlags(flag.CommandLine, nil)
+	flag.Parse()
+
+	if err := cfg.validate(); err != nil {
+		flog.Fatal(err)
+	}
+	if flag.NArg() != 1 {
+		flog.Fatalf("expecting one argument: feed path. got %d", flag.NArg())
+	}
+
+	feed, err := redhat.LoadFeed(flag.Arg(0))
+	if err != nil {
+		flog.Fatal(err)
+	}
+	chk, err := feed.Checker()
+	if err != nil {
+		flog.Fatal(err)
+	}
+
+	// adjust indexes
+	cfg.pkgs--
+	cfg.distro--
+	cfg.cve--
+
+	if err := filter(chk, &cfg, os.Stdin, os.Stdout); err != nil {
+		flog.Fatal(err)
+	}
+}
+
+func filter(chk rpm.Checker, cfg *config, r io.Reader, w io.Writer) error {
+	cr := csv.NewReader(r)
+	cw := csv.NewWriter(w)
+
+	for {
+		// read
+		row, err := cr.Read()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		// check indexes
+		if err := cfg.checkIndexes(len(row)); err != nil {
+			return err
+		}
+
+		// filter
+		pkgs := strings.Split(row[cfg.pkgs], cfg.pkgsSep)
+		filtered, err := rpm.FilterFixedPackages(chk, pkgs, row[cfg.distro], row[cfg.cve])
+		if err != nil {
+			return fmt.Errorf("failed to filter packages: %v", err)
+		}
+		row[cfg.pkgs] = strings.Join(filtered, cfg.pkgsSep)
+
+		// write
+		if err := cw.Write(row); err != nil {
+			return err
+		}
+		cw.Flush()
+		if err := cw.Error(); err != nil {
+			return err
+		}
+	}
+}
+
+type config struct {
+	pkgs, distro, cve int
+	pkgsSep           string
+}
+
+func (cfg *config) addFlags() {
+	flag.IntVar(&cfg.pkgs, "pkgs", 0, "csv field which holds the packages. starts with 1")
+	flag.IntVar(&cfg.distro, "distro", 0, "csv field which holds the distribution CPE. starts with 1")
+	flag.IntVar(&cfg.cve, "cve", 0, "csv field which holds the CVE. starts with 1")
+	flag.StringVar(&cfg.pkgsSep, "pkgs-sep", "\x02", "separator to use for the packages field")
+}
+
+func (cfg *config) validate() error {
+	if cfg.pkgs <= 0 || cfg.distro <= 0 || cfg.cve <= 0 {
+		flog.Fatalf("indexes must be postive: distro=%d pkgs=%d cve=%d", cfg.distro, cfg.pkgs, cfg.cve)
+	}
+	return nil
+}
+
+func (cfg *config) checkIndexes(n int) error {
+	if cfg.pkgs >= n {
+		return fmt.Errorf("not enough fields. have %d fields but pkgs index is %d", n, cfg.pkgs+1)
+	}
+	if cfg.distro >= n {
+		return fmt.Errorf("not enough fields. have %d fields but distro index is %d", n, cfg.distro+1)
+	}
+	if cfg.cve >= n {
+		return fmt.Errorf("not enough fields. have %d fields but cve index is %d", n, cfg.cve+1)
+	}
+	return nil
+}

--- a/cmd/redhat_filter/main_test.go
+++ b/cmd/redhat_filter/main_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/facebookincubator/nvdtools/rpm"
+	"github.com/facebookincubator/nvdtools/wfn"
+)
+
+func TestFilter(t *testing.T) {
+	cfg := config{
+		pkgs:    0,
+		distro:  1,
+		cve:     2,
+		pkgsSep: ",",
+	}
+	chk := testChecker("foo")
+
+	for i, tc := range []struct {
+		in, out []string
+		fail    bool
+	}{
+		// pkgs,distro,cve
+		{
+			in:  []string{`name-epoch:version-release.arch.src,cpe:/a:redhat:enterprise_linux:7,CVE-X-Y`},
+			out: []string{`name-epoch:version-release.arch.src,cpe:/a:redhat:enterprise_linux:7,CVE-X-Y`},
+		},
+		{
+			in:  []string{`"foo-epoch:version-release.arch.src,bar-epoch:version-release.arch.src",cpe:/a:redhat:enterprise_linux:7,CVE-X-Y`},
+			out: []string{`bar-epoch:version-release.arch.src,cpe:/a:redhat:enterprise_linux:7,CVE-X-Y`},
+		},
+		{
+			in:  []string{`"foo-epoch:version-release.arch.src,not a rpm package",cpe:/a:redhat:enterprise_linux:7,CVE-X-Y`},
+			out: []string{`not a rpm package,cpe:/a:redhat:enterprise_linux:7,CVE-X-Y`},
+		},
+		{
+			in: []string{
+				`"foo-epoch:version-release.arch.src,bar-epoch:version-release.arch.src",cpe:/a:redhat:enterprise_linux:7,CVE-X-Y`,
+				`"foo-epoch:version-release.arch.src,not a rpm package",cpe:/a:redhat:enterprise_linux:7,CVE-X-Y`,
+			},
+			out: []string{
+				`bar-epoch:version-release.arch.src,cpe:/a:redhat:enterprise_linux:7,CVE-X-Y`,
+				`not a rpm package,cpe:/a:redhat:enterprise_linux:7,CVE-X-Y`,
+			},
+		},
+		{
+			in:   []string{`package,not a valid cpe so should fail,some cve`},
+			fail: true,
+		},
+		{
+			in:   []string{`wrong number of fields,should be 3 but have 2`},
+			fail: true,
+		},
+		{
+			in:  []string{`package,cpe:/,cve,some,additional,things,shouldn't change anything!`},
+			out: []string{`package,cpe:/,cve,some,additional,things,shouldn't change anything!`},
+		},
+	} {
+		t.Run(fmt.Sprintf("case-%d", i+1), func(t *testing.T) {
+			r := strings.NewReader(strings.Join(tc.in, "\n"))
+			var w strings.Builder
+
+			if err := filter(chk, &cfg, r, &w); err != nil {
+				if !tc.fail {
+					t.Fatalf("shouldn't have failed for %v, but did: %v", tc.in, err)
+				}
+				return
+			}
+			if tc.fail {
+				t.Fatalf("should've failed for %v, but didn't", tc.in)
+			}
+
+			want := tc.out
+			if have := strings.Split(strings.TrimSpace(w.String()), "\n"); !reflect.DeepEqual(have, want) {
+				t.Fatalf("wrong output. have: %v, want: %v", have, want)
+			}
+		})
+	}
+}
+
+// fixed packages are the ones with this name
+type testChecker string
+
+func (name testChecker) Check(pkg *rpm.Package, distro *wfn.Attributes, cve string) bool {
+	return pkg.Name == string(name)
+}

--- a/providers/redhat/check/check_cve.go
+++ b/providers/redhat/check/check_cve.go
@@ -1,0 +1,127 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/facebookincubator/nvdtools/providers/redhat/schema"
+	"github.com/facebookincubator/nvdtools/rpm"
+	"github.com/facebookincubator/nvdtools/wfn"
+)
+
+var NoCheckers = errors.New("no applicable checkers")
+
+func CVEChecker(cve *schema.CVE) (rpm.Checker, error) {
+	var chks []rpm.Checker
+
+	if archks, err := affectedReleaseCheckers(cve); err != nil {
+		return nil, fmt.Errorf("can't construct checkers for affected release: %v", err)
+	} else {
+		chks = archks
+	}
+
+	if pschks, err := packageStateCheckers(cve); err != nil {
+		return nil, fmt.Errorf("can't construct checkers for package state: %v", err)
+	} else {
+		chks = append(chks, pschks...)
+	}
+
+	if len(chks) == 0 {
+		return nil, NoCheckers
+	}
+
+	return &cveChecker{cve.Name, chks}, nil
+}
+
+func affectedReleaseCheckers(cve *schema.CVE) ([]rpm.Checker, error) {
+	var chks []rpm.Checker
+
+	for _, ar := range cve.AffectedRelease {
+		if ar.CPE == "" {
+			continue
+		}
+
+		d, err := wfn.Parse(ar.CPE)
+		if err != nil {
+			return nil, fmt.Errorf("can't parse distro cpe %q: %v", ar.CPE, err)
+		}
+		// TODO we need to do this because RedHat sometimes sets `a` as part for RHEL-X, when it should be `o`
+		d.Part = wfn.Any
+
+		var pc pkgCheck = constPkgChecker(true) // match all packages
+		if ar.Package != "" {
+			// add .src to parse it correctly, they're all src rpms
+			if p, err := rpm.Parse(ar.Package + ".src"); err == nil {
+				pc = affectedReleasePkgChecker(*p)
+			}
+		}
+
+		chks = append(chks, &singleChecker{d, pc})
+	}
+
+	return chks, nil
+}
+
+func packageStateCheckers(cve *schema.CVE) ([]rpm.Checker, error) {
+	var chks []rpm.Checker
+
+	for _, ps := range cve.PackageState {
+		if ps.FixState != "" && !schema.IsFixed(ps.FixState) {
+			// if the package hasn't been fixed, continue
+			continue
+		}
+
+		if ps.CPE == "" {
+			continue
+		}
+
+		d, err := wfn.Parse(ps.CPE)
+		if err != nil {
+			return nil, fmt.Errorf("can't parse distro cpe %q: %v", ps.CPE, err)
+		}
+		// TODO we need to do this because RedHat sometimes sets `a` as part for RHEL-X, when it should be `o`
+		d.Part = wfn.Any
+
+		var pc pkgCheck = constPkgChecker(true) // match all packages
+		if ps.PackageName != "" {
+			pc = packageStatePkgChecker(ps.PackageName)
+		}
+
+		chks = append(chks, &singleChecker{d, pc})
+	}
+
+	return chks, nil
+}
+
+// this is an or checker, if any of checkers returns true, result is true
+type cveChecker struct {
+	cve  string
+	chks []rpm.Checker
+}
+
+// Check is part of the rpm.Check interface
+func (c *cveChecker) Check(pkg *rpm.Package, distro *wfn.Attributes, cve string) bool {
+	if cve != c.cve {
+		return false
+	}
+	for _, chk := range c.chks {
+		if chk.Check(pkg, distro, cve) {
+			return true
+		}
+	}
+	return false
+}

--- a/providers/redhat/check/check_cve_test.go
+++ b/providers/redhat/check/check_cve_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/facebookincubator/nvdtools/providers/redhat/schema"
+	"github.com/facebookincubator/nvdtools/rpm"
+	"github.com/facebookincubator/nvdtools/wfn"
+)
+
+func TestCVEChecker(t *testing.T) {
+	var cve schema.CVE
+	if err := json.NewDecoder(strings.NewReader(cveStr)).Decode(&cve); err != nil {
+		t.Fatal(err)
+	}
+
+	chk, err := CVEChecker(&cve)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pkg, _ := rpm.Parse("firefox-68.1.0-1.el8_0.src")
+
+	for i, tc := range []struct {
+		distroVersion string
+		expect        bool
+	}{
+		{"5", false},
+		{"6", true},
+		{"7", true},
+		{"8", true},
+		{"9", false},
+	} {
+		t.Run(fmt.Sprintf("case-%d", i+1), func(t *testing.T) {
+			distro := wfn.Attributes{
+				Part:    "o",
+				Vendor:  "redhat",
+				Product: "enterprise_linux",
+				Version: tc.distroVersion,
+			}
+			if got := chk.Check(pkg, &distro, "CVE-2019-11735"); got != tc.expect {
+				t.Fatalf("expecting %v for version %q, got %v", tc.expect, tc.distroVersion, got)
+			}
+			if chk.Check(pkg, &distro, "CVE-some-other") {
+				t.Fatalf("shouldn't match when unknown cve is given")
+			}
+		})
+	}
+}
+
+var cveStr = `
+  {
+    "name": "CVE-2019-11735",
+    "threat_severity": "Important",
+    "public_date": "2019-09-03T00:00:00",
+    "bugzilla": {
+      "description": "\nCVE-2019-11735 Mozilla: Memory safety bugs fixed in Firefox 69 and Firefox ESR 68.1\n    ",
+      "id": "1748661",
+      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1748661"
+    },
+    "CVSS3": {
+      "cvss3_base_score": "7.5",
+      "cvss3_scoring_vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "status": "verified"
+    },
+    "cwe": "CWE-120",
+    "details": [
+      "\n** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided.\n    "
+    ],
+    "references": [
+      "\nhttps://www.mozilla.org/en-US/security/advisories/mfsa2019-26/#CVE-2019-11735\n    "
+    ],
+    "acknowledgement": "\nRed Hat would like to thank the Mozilla project for reporting this issue. Upstream acknowledges Mikhail Gavrilov, Tyson Smith, Marcia Knous, Tom Ritter, Philipp, and Bob Owens as the original reporters.\n    ",
+    "upstream_fix": "firefox 68.1",
+    "affected_release": [
+      {
+        "product_name": "Red Hat Enterprise Linux 8",
+        "release_date": "2019-09-04T00:00:00",
+        "advisory": "RHSA-2019:2663",
+        "package": "firefox-68.1.0-1.el8_0",
+        "cpe": "cpe:/a:redhat:enterprise_linux:8"
+      }
+    ],
+    "package_state": [
+      {
+        "product_name": "Red Hat Enterprise Linux 5",
+        "fix_state": "Out of support scope",
+        "package_name": "firefox",
+        "cpe": "cpe:/o:redhat:enterprise_linux:5"
+      },
+      {
+        "product_name": "Red Hat Enterprise Linux 6",
+        "fix_state": "Not affected",
+        "package_name": "firefox",
+        "cpe": "cpe:/o:redhat:enterprise_linux:6"
+      },
+      {
+        "product_name": "Red Hat Enterprise Linux 7",
+        "fix_state": "Not affected",
+        "package_name": "firefox",
+        "cpe": "cpe:/o:redhat:enterprise_linux:7"
+      }
+    ]
+  }
+`

--- a/providers/redhat/check/check_pkg.go
+++ b/providers/redhat/check/check_pkg.go
@@ -1,0 +1,81 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"github.com/facebookincubator/nvdtools/rpm"
+	"github.com/facebookincubator/nvdtools/wfn"
+)
+
+type pkgCheck interface {
+	checkPkg(*rpm.Package) bool
+}
+
+type constPkgChecker bool
+
+func (c constPkgChecker) checkPkg(_ *rpm.Package) bool {
+	return bool(c)
+}
+
+// string is package name
+type packageStatePkgChecker string
+
+func (c packageStatePkgChecker) checkPkg(pkg *rpm.Package) bool {
+	return pkg.Name == string(c)
+}
+
+// package is the full package to match
+type affectedReleasePkgChecker rpm.Package
+
+func (c affectedReleasePkgChecker) checkPkg(pkg *rpm.Package) bool {
+	// if both have names and they're not the same, false
+	if c.Name != "" && pkg.Name != "" && c.Name != pkg.Name {
+		return false
+	}
+	// if both have archs and they're not the same, false
+	if c.Arch != "" && pkg.Arch != "" && c.Arch != pkg.Arch {
+		return false
+	}
+	if rpm.LabelCompare(pkg.Label, c.Label) < 0 {
+		return false
+	}
+
+	return true
+}
+
+type singleChecker struct {
+	distro *wfn.Attributes
+	pkgCheck
+}
+
+func (c *singleChecker) Check(pkg *rpm.Package, distro *wfn.Attributes, cve string) bool {
+	if pkg == nil {
+		// just a sanity check, shouldn't even be called with nil
+		return false
+	}
+	if !c.checkPkg(pkg) {
+		// package doesn't match, return false
+		return false
+	}
+
+	if distro != nil && c.distro != nil {
+		if !wfn.Match(distro, c.distro) {
+			// if they don't match, return false
+			return false
+		}
+	}
+
+	return true
+}

--- a/providers/redhat/check/check_pkg_test.go
+++ b/providers/redhat/check/check_pkg_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/facebookincubator/nvdtools/rpm"
+	"github.com/facebookincubator/nvdtools/wfn"
+)
+
+var (
+	pkg *rpm.Package
+)
+
+func init() {
+	pkg, _ = rpm.Parse("name-1:v2-rel.arch.rpm")
+	// pkg = {
+	// 	Name: "name",
+	// 	Label: {
+	// 		Epoch: "1",
+	// 		Version: "v2",
+	// 		Release: "rel",
+	// 	},
+	// 	Arch: "arch",
+	// }
+}
+
+func TestConstPkgChecker(t *testing.T) {
+	for i, tc := range []struct {
+		conf   bool
+		expect bool
+	}{
+		{true, true},
+		{false, false},
+	} {
+		t.Run(fmt.Sprintf("case-%d", i+1), func(t *testing.T) {
+			if got := constPkgChecker(tc.conf).checkPkg(pkg); got != tc.expect {
+				t.Fatalf("pkg checker (%v) should return %v, got %v", tc.conf, tc.expect, got)
+			}
+		})
+	}
+}
+
+func TestPackageStatePkgChecker(t *testing.T) {
+	for i, tc := range []struct {
+		conf   string
+		expect bool
+	}{
+		{"name", true},
+		{"something", false},
+	} {
+		t.Run(fmt.Sprintf("case-%d", i+1), func(t *testing.T) {
+			if got := packageStatePkgChecker(tc.conf).checkPkg(pkg); got != tc.expect {
+				t.Fatalf("pkg checker (%v) should return %v, got %v", tc.conf, tc.expect, got)
+			}
+		})
+	}
+}
+
+func TestAffectedReleasePkgChecker(t *testing.T) {
+	for i, tc := range []struct {
+		conf   rpm.Package
+		expect bool
+	}{
+		// config version is higher, so it means pkg wasn't fixed
+		{rpm.Package{Name: "name", Label: rpm.Label{Epoch: "1", Version: "v3"}}, false},
+		// config version is lower, so it means pkg was fixed
+		{rpm.Package{Name: "name", Label: rpm.Label{Epoch: "1", Version: "v1"}}, true},
+		// name is not the same, wasn't fixed
+		{rpm.Package{Name: "name2"}, false},
+		// arch is not the same, wasn't fixed
+		{rpm.Package{Name: "name", Arch: "aaaa"}, false},
+	} {
+		t.Run(fmt.Sprintf("case-%d", i+1), func(t *testing.T) {
+			if got := affectedReleasePkgChecker(tc.conf).checkPkg(pkg); got != tc.expect {
+				t.Fatalf("pkg checker (%v) should return %v, got %v", tc.conf, tc.expect, got)
+			}
+		})
+	}
+}
+
+func TestSingleChecker(t *testing.T) {
+	// since we have unit tests for all other pkg checkers, we're just gonna use the const one for simplicity
+	pc := constPkgChecker(true)
+	cfgDistro := wfn.Attributes{
+		Part:    "o",
+		Vendor:  "vendor",
+		Product: "product",
+		Version: "4",
+	}
+	chk := &singleChecker{&cfgDistro, pc}
+
+	for i, tc := range []struct {
+		distro wfn.Attributes
+		expect bool
+	}{
+		// version is the same as the fixed one, expecting true
+		{wfn.Attributes{Part: "o", Vendor: "vendor", Product: "product", Version: "4"}, true},
+		// part is different, expecting false
+		{wfn.Attributes{Part: "a", Vendor: "vendor", Product: "product", Version: "4"}, false},
+		// product name is different, expecting false
+		{wfn.Attributes{Part: "a", Vendor: "vendor", Product: "producttt", Version: "4"}, false},
+	} {
+		t.Run(fmt.Sprintf("case-%d", i+1), func(t *testing.T) {
+			// pkg can be anything other than nil since we're using const pkg checker
+			if have := chk.Check(pkg, &tc.distro, ""); have != tc.expect {
+				t.Fatalf("wrong check result for %q: have %v, expect %v", tc.distro.BindToURI(), have, tc.expect)
+			}
+		})
+	}
+}

--- a/providers/redhat/feed.go
+++ b/providers/redhat/feed.go
@@ -1,0 +1,73 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redhat
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/facebookincubator/nvdtools/providers/redhat/check"
+	"github.com/facebookincubator/nvdtools/providers/redhat/schema"
+	"github.com/facebookincubator/nvdtools/rpm"
+	"github.com/facebookincubator/nvdtools/wfn"
+)
+
+type Feed map[string]*schema.CVE
+
+func LoadFeed(path string) (Feed, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("can't open file %q: %v", path, err)
+	}
+	defer f.Close()
+	return loadFeed(f)
+}
+
+func loadFeed(r io.Reader) (Feed, error) {
+	var feed Feed
+	if err := json.NewDecoder(r).Decode(&feed); err != nil {
+		return nil, fmt.Errorf("can't decode feed: %v", err)
+	}
+	return feed, nil
+}
+
+func (feed Feed) Checker() (rpm.Checker, error) {
+	mc := make(mapChecker, len(feed))
+	var err error
+	for cveid, cve := range feed {
+		if mc[cveid], err = check.CVEChecker(cve); err != nil {
+			if err == check.NoCheckers {
+				// no checkers could be created, just skip it
+				delete(mc, cveid)
+				continue
+			}
+			return nil, fmt.Errorf("can't create a checker for %q: %v", cveid, err)
+		}
+	}
+	return mc, nil
+}
+
+// cve -> checker
+type mapChecker map[string]rpm.Checker
+
+// Check is part of the rpm.Check interface
+func (c mapChecker) Check(pkg *rpm.Package, distro *wfn.Attributes, cve string) bool {
+	if chk, ok := c[cve]; ok {
+		return chk.Check(pkg, distro, cve)
+	}
+	return false
+}

--- a/providers/redhat/schema/convert.go
+++ b/providers/redhat/schema/convert.go
@@ -206,7 +206,7 @@ func (ps *PackageState) createNode() (*nvd.NVDCVEFeedJSON10DefNode, error) {
 			{
 				Cpe22Uri:   pkgAttrs.BindToURI(),
 				Cpe23Uri:   pkgAttrs.BindToFmtString(),
-				Vulnerable: IsVulnerable(ps.FixState),
+				Vulnerable: !IsFixed(ps.FixState),
 			},
 			// distribution
 			{

--- a/providers/redhat/schema/convertutils.go
+++ b/providers/redhat/schema/convertutils.go
@@ -48,7 +48,7 @@ func findCWEs(s string) []string {
 	return cweRegex.FindAllString(s, -1)
 }
 
-func IsVulnerable(fixState string) bool {
+func IsFixed(fixState string) bool {
 	// $ jq 'to_entries | .[].value.package_state' redhat.json | grep fix_state | sort -u
 	// "fix_state": "Affected",
 	// "fix_state": "Fix deferred",
@@ -60,12 +60,12 @@ func IsVulnerable(fixState string) bool {
 
 	switch strings.TrimSpace(strings.ToLower(fixState)) {
 	case "affected", "fix deferred", "new", "out of support scope", "will not fix":
-		return true
-	case "not affected", "under investigation":
 		return false
+	case "not affected", "under investigation":
+		return true
 	default:
 		log.Printf("unknown fix state: %q", fixState)
-		return false
+		return true
 	}
 }
 

--- a/rpm/checker_test.go
+++ b/rpm/checker_test.go
@@ -1,0 +1,101 @@
+package rpm
+
+import (
+	"testing"
+
+	"github.com/facebookincubator/nvdtools/wfn"
+)
+
+func TestCheck(t *testing.T) {
+	foo := "foo-v1-rel.arch.rpm"
+	bar := "bar-v1-rel.arch.rpm"
+	distro := "cpe:/o:vendor:product:version"
+
+	// only foo has been fixed
+	chk := nameChecker("foo")
+
+	if c, err := Check(chk, foo, distro, ""); err != nil {
+		t.Fatal(err)
+	} else if !c {
+		t.Fatal("expecting for foo to be fixed, but check returned false")
+	}
+
+	if c, err := Check(chk, bar, distro, ""); err != nil {
+		t.Fatal(err)
+	} else if c {
+		t.Fatal("expecting for bar not to be fixed, but check returned true")
+	}
+}
+
+func TestFilterFixedPackages(t *testing.T) {
+	pkgs := []string{"foo-v1-rel.arch.rpm", "bar-v1-rel.arch.rpm"}
+	distro := "cpe:/o:vendor:product:version"
+
+	// only foo has been fixed
+	chk := nameChecker("foo")
+	filtered, err := FilterFixedPackages(chk, pkgs, distro, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// expecting to filter foo out and leave only bar
+	if len(filtered) != 1 || filtered[0] != "bar-v1-rel.arch.rpm" {
+		t.Fatalf("expecting to find only the bar package, got %v", filtered)
+	}
+}
+
+func TestCheckAnyAndAll(t *testing.T) {
+	for i := 0; i <= 100; i++ {
+		chks := getCheckers(i)
+		// only false when all checkers are false
+		if c := CheckAny(chks...).Check(nil, nil, ""); c == (i == 0) {
+			t.Fatalf("unexpected ANY result for %d checkers: %v", i, c)
+		}
+		// only true when all checkers are true
+		if c := CheckAll(chks...).Check(nil, nil, ""); c != isAllOnes(i) {
+			t.Fatalf("unexpected ALL result for %d checkers: %v", i, c)
+		}
+	}
+}
+
+// Check method returns true if package name is the one specified
+type nameChecker string
+
+func (c nameChecker) Check(pkg *Package, _ *wfn.Attributes, _ string) bool {
+	return pkg.Name == string(c)
+}
+
+// Check method returns whatever is the value of it
+type constChecker bool
+
+func (c constChecker) Check(_ *Package, _ *wfn.Attributes, _ string) bool {
+	return bool(c)
+}
+
+// returns true and false checkers
+// if we represent a number in binary format, then
+//	- the number of true checkers is the number of 1s
+//	- the number of false checkers is the number of 0s
+func getCheckers(n int) []Checker {
+	trueChk := constChecker(true)
+	falseChk := constChecker(false)
+
+	var chks []Checker
+	for ; n > 0; n >>= 1 {
+		if n&1 == 1 {
+			chks = append(chks, trueChk)
+		} else {
+			chks = append(chks, falseChk)
+		}
+	}
+	return chks
+}
+
+// is the number 2^x - 1
+func isAllOnes(n int) bool {
+	if n == 0 {
+		return false
+	}
+	for ; n&1 == 1; n >>= 1 {
+	}
+	return n == 0
+}


### PR DESCRIPTION
RedHat feed

RedHat feed tells us which rpm packages have been fixed for which
release for which CVE.
This binary implements this kind of filtering.
Input is in csv format and you specify which fields contain packages,
distribution and cve. Output is the same format as input, just has
packges filtered out. Only the ones that haven't been reported as fixed
stay in the output.

go test ./...