### PR TITLE
[rpm/redhat] Minor fixes from the previous pull request

### DIFF
--- a/providers/redhat/check/check_cve.go
+++ b/providers/redhat/check/check_cve.go
@@ -59,7 +59,7 @@ func affectedReleaseCheckers(cve *schema.CVE) ([]rpm.Checker, error) {
 		if err != nil {
 			return nil, fmt.Errorf("can't parse distro cpe %q: %v", ar.CPE, err)
 		}
-		// TODO we need to do this because RedHat sometimes sets `a` as part for RHEL-X, when it should be `o`
+		// XXX we need to do this because RedHat sometimes sets `a` as part for RHEL-X, when it should be `o`
 		d.Part = wfn.Any
 
 		var pc pkgCheck = constPkgChecker(true) // match all packages
@@ -93,7 +93,7 @@ func packageStateCheckers(cve *schema.CVE) ([]rpm.Checker, error) {
 		if err != nil {
 			return nil, fmt.Errorf("can't parse distro cpe %q: %v", ps.CPE, err)
 		}
-		// TODO we need to do this because RedHat sometimes sets `a` as part for RHEL-X, when it should be `o`
+		// XXX we need to do this because RedHat sometimes sets `a` as part for RHEL-X, when it should be `o`
 		d.Part = wfn.Any
 
 		var pc pkgCheck = constPkgChecker(true) // match all packages

--- a/providers/redhat/check/check_pkg.go
+++ b/providers/redhat/check/check_pkg.go
@@ -56,8 +56,8 @@ func (c affectedReleasePkgChecker) checkPkg(pkg *rpm.Package) bool {
 }
 
 type singleChecker struct {
-	distro *wfn.Attributes
-	pkgCheck
+	distro     *wfn.Attributes
+	pkgChecker pkgCheck
 }
 
 func (c *singleChecker) Check(pkg *rpm.Package, distro *wfn.Attributes, cve string) bool {
@@ -65,7 +65,7 @@ func (c *singleChecker) Check(pkg *rpm.Package, distro *wfn.Attributes, cve stri
 		// just a sanity check, shouldn't even be called with nil
 		return false
 	}
-	if !c.checkPkg(pkg) {
+	if !c.pkgChecker.checkPkg(pkg) {
 		// package doesn't match, return false
 		return false
 	}

--- a/providers/redhat/schema/convertutils.go
+++ b/providers/redhat/schema/convertutils.go
@@ -59,9 +59,9 @@ func IsFixed(fixState string) bool {
 	// "fix_state": "Will not fix",
 
 	switch strings.TrimSpace(strings.ToLower(fixState)) {
-	case "affected", "fix deferred", "new", "out of support scope", "will not fix":
+	case "affected", "fix deferred", "new", "out of support scope", "will not fix", "under investigation":
 		return false
-	case "not affected", "under investigation":
+	case "not affected":
 		return true
 	default:
 		log.Printf("unknown fix state: %q", fixState)

--- a/rpm/checker_test.go
+++ b/rpm/checker_test.go
@@ -1,6 +1,21 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rpm
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/facebookincubator/nvdtools/wfn"
@@ -28,7 +43,7 @@ func TestCheck(t *testing.T) {
 }
 
 func TestFilterFixedPackages(t *testing.T) {
-	pkgs := []string{"foo-v1-rel.arch.rpm", "bar-v1-rel.arch.rpm"}
+	pkgs := []string{"foo-v1-rel.arch.rpm", "bar-v1-rel.arch.rpm", "malformed-rpm"}
 	distro := "cpe:/o:vendor:product:version"
 
 	// only foo has been fixed
@@ -37,9 +52,10 @@ func TestFilterFixedPackages(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// expecting to filter foo out and leave only bar
-	if len(filtered) != 1 || filtered[0] != "bar-v1-rel.arch.rpm" {
-		t.Fatalf("expecting to find only the bar package, got %v", filtered)
+	// expecting to filter foo out and leave only bar and malformed
+	filteredWant := []string{"bar-v1-rel.arch.rpm", "malformed-rpm"}
+	if !reflect.DeepEqual(filtered, filteredWant) {
+		t.Fatalf("wrong filtering\n\thave: %v\n\twant: %v", filtered, filteredWant)
 	}
 }
 


### PR DESCRIPTION
- add license header to rpm/checker_test.go
- add malformed package to the filter test
- switch TODO for XXX
- un-embed the pkgCheck from the singleChecker
- redhat: under investigation -> not fixed

Test: `go test ./...`