### PR TITLE
[cvss3] Add support for new version of CVSS3 (3.1)

### DIFF
--- a/cvss3/score.go
+++ b/cvss3/score.go
@@ -141,7 +141,14 @@ func (v Vector) modifiedImpactScore() float64 {
 		0.915,
 	)
 	if v.modifiedScopeChanged() {
-		return 7.52*(iscModified-0.029) - 3.25*math.Pow((iscModified-0.02), 15)
+		switch v.version {
+		case version(1):
+			return 7.52*(iscModified-0.029) - 3.25*math.Pow((iscModified*0.9731-0.02), 13)
+		case version(0):
+			fallthrough
+		default:
+			return 7.52*(iscModified-0.029) - 3.25*math.Pow((iscModified-0.02), 15)
+		}
 	} else {
 		return 6.42 * iscModified
 	}

--- a/cvss3/score_test.go
+++ b/cvss3/score_test.go
@@ -127,3 +127,31 @@ func TestScores(t *testing.T) {
 		})
 	}
 }
+
+func TestScoresV30V31(t *testing.T) {
+	vec := "AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:H/MI:H/MA:H"
+
+	for _, c := range []struct {
+		ver                           version
+		base, temporal, environmental float64
+	}{
+		{version(0), 10.0, 8.1, 5.5},
+		{version(1), 10.0, 8.1, 5.6},
+	} {
+		fullVec := fmt.Sprintf("%s%s/%s", prefix, c.ver, vec)
+		v, err := VectorFromString(fullVec)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if base := v.BaseScore(); base != c.base {
+			t.Fatalf("v %s: base score wrong: have %.1f, want %.1f", c.ver, base, c.base)
+		}
+		if temporal := v.TemporalScore(); temporal != c.temporal {
+			t.Fatalf("v %s: temporal score wrong: have %.1f, want %.1f", c.ver, temporal, c.temporal)
+		}
+		if environmental := v.EnvironmentalScore(); environmental != c.environmental {
+			t.Fatalf("v %s: environmental score wrong: have %.1f, want %.1f", c.ver, environmental, c.environmental)
+		}
+	}
+}

--- a/cvss3/vector_test.go
+++ b/cvss3/vector_test.go
@@ -19,32 +19,74 @@ import (
 	"testing"
 )
 
+func TestVersionFromString(t *testing.T) {
+	for i, c := range []struct {
+		s    string
+		v    version
+		fail bool
+	}{
+		{"3.0", version(0), false},
+		{"3.1", version(1), false},
+		{"3.2", version(0), true},
+	} {
+		t.Run(fmt.Sprintf("case %2d", i+1), func(t *testing.T) {
+			if v, err := versionFromString(c.s); err != nil {
+				if !c.fail {
+					t.Fatal(err)
+				}
+			} else if c.fail {
+				t.Fatalf("versionFromString(%q) should've failed, but didn't", c.s)
+			} else if v != c.v {
+				t.Fatalf("versionFromString(%q) = %v, but got %v", c.s, c.v, v)
+			}
+		})
+	}
+}
+
+func TestVersionInVector(t *testing.T) {
+	for i, c := range []struct {
+		vec string
+		ver version
+	}{
+		{"CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H/E:H/RL:O/RC:C", version(0)},
+		{"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H/E:H/RL:O/RC:C", version(1)},
+	} {
+		t.Run(fmt.Sprintf("case %2d", i+1), func(t *testing.T) {
+			if v, err := VectorFromString(c.vec); err != nil {
+				t.Fatal(err)
+			} else if v.version != c.ver {
+				t.Fatalf("version(%q) = %v, but got %v", c.vec, c.ver, v.version)
+			}
+		})
+	}
+}
+
 func TestFromString(t *testing.T) {
 	cases := []string{
 		"CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H/E:H/RL:O/RC:C",
-		"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N/E:U/RL:O/RC:C",
+		"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N/E:U/RL:O/RC:C",
 		"CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:F/RL:O/RC:C",
-		"CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:L/I:N/A:N/E:U/RL:O/RC:C",
+		"CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:L/I:N/A:N/E:U/RL:O/RC:C",
 		"CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:H/E:U/RL:T/RC:C",
-		"CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N/E:U/RL:O/RC:C",
+		"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N/E:U/RL:O/RC:C",
 		"CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H/E:U/RL:T/RC:C",
-		"CVSS:3.0/AV:A/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N/E:U/RL:T/RC:C",
+		"CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N/E:U/RL:T/RC:C",
 		"CVSS:3.0/AV:L/AC:L/PR:L/UI:R/S:U/C:L/I:N/A:N/E:U/RL:U/RC:C",
-		"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N/E:U/RL:U/RC:C",
+		"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N/E:U/RL:U/RC:C",
 		"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:T/RC:C",
-		"CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:N/E:F/RL:O/RC:C",
+		"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:N/E:F/RL:O/RC:C",
 		"CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N/E:U/RL:U/RC:C",
-		"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:T/RC:C",
+		"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:T/RC:C",
 		"CVSS:3.0/AV:L/AC:H/PR:N/UI:R/S:C/C:L/I:N/A:N/E:U/RL:O/RC:C",
-		"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:N/E:U/RL:T/RC:C",
+		"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:N/E:U/RL:T/RC:C",
 		"CVSS:3.0/AV:A/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H/E:U/RL:U/RC:C",
-		"CVSS:3.0/AV:A/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+		"CVSS:3.1/AV:A/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
 		"CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:O/RC:C",
-		"CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N/E:U/RL:U/RC:C",
+		"CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N/E:U/RL:U/RC:C",
 		"CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N/E:U/RL:T/RC:C",
-		"CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:N/E:P/RL:U/RC:C",
+		"CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:N/E:P/RL:U/RC:C",
 		"CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N/E:U/RL:T/RC:C",
-		"CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N/E:U/RL:O/RC:C",
+		"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N/E:U/RL:O/RC:C",
 		"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/RL:T/RC:C",
 	}
 


### PR DESCRIPTION
https://www.first.org/cvss/user-guide

This pull requests add support for CVSS version 3.1
The formula to calculate modified impact sub-score was changed, and it
can be seen in the code as well.
Added tests for new changes.