### PR TITLE
Extend CVSS3 specification: Modified Temporal metrics

### DIFF
--- a/cvss3/environmental_metrics.go
+++ b/cvss3/environmental_metrics.go
@@ -28,7 +28,12 @@ type EnvironmentalMetrics struct {
 	ModifiedConfidentiality
 	ModifiedIntegrity
 	ModifiedAvailability
+	ModifiedExploitCodeMaturity
+	ModifiedRemediationLevel
+	ModifiedReportConfidence
 }
+
+/******** CONFIDENTIALITY REQUIREMENT (CR) ********/
 
 type ConfidentialityRequirement int
 
@@ -65,6 +70,8 @@ func (cr *ConfidentialityRequirement) parse(str string) error {
 	return fmt.Errorf("illegal confidentiality requirement code %s", str)
 }
 
+/******** INTEGRITY REQUIREMENT (IR) ********/
+
 type IntegrityRequirement int
 
 const (
@@ -100,6 +107,8 @@ func (ir *IntegrityRequirement) parse(str string) error {
 	return fmt.Errorf("illegal integrity requirement code %s", str)
 }
 
+/******** AVAILAVILITY REQUIREMENT (AR) ********/
+
 type AvailabilityRequirement int
 
 const (
@@ -134,6 +143,8 @@ func (ar *AvailabilityRequirement) parse(str string) error {
 	}
 	return fmt.Errorf("illegal availability requirement code %s", str)
 }
+
+/******** MODIFIED ATTACK VECTOR (MAV) ********/
 
 type ModifiedAttackVector AttackVector
 
@@ -171,6 +182,8 @@ func (mav *ModifiedAttackVector) parse(str string) error {
 	return err
 }
 
+/******** MODIFIED ATTACK COMPLEXITY (MAC) ********/
+
 type ModifiedAttackComplexity AttackComplexity
 
 const (
@@ -206,6 +219,8 @@ func (mac *ModifiedAttackComplexity) parse(str string) error {
 	*mac = ModifiedAttackComplexity(ac)
 	return err
 }
+
+/******** MODIFIED PRIVILIGES REQUIRED (MPR) ********/
 
 type ModifiedPrivilegesRequired PrivilegesRequired
 
@@ -243,6 +258,8 @@ func (mpr *ModifiedPrivilegesRequired) parse(str string) error {
 	return err
 }
 
+/******** MODIFIED USER INTERACTION (MUI) ********/
+
 type ModifiedUserInteraction UserInteraction
 
 const (
@@ -279,6 +296,8 @@ func (mui *ModifiedUserInteraction) parse(str string) error {
 	return err
 }
 
+/******** MODIFIED SCOPE (MS) ********/
+
 type ModifiedScope Scope
 
 const (
@@ -307,6 +326,8 @@ func (ms *ModifiedScope) parse(str string) error {
 	*ms = ModifiedScope(s)
 	return err
 }
+
+/******** MODIFIED CONFIDENTIALITY (MC) ********/
 
 type ModifiedConfidentiality Confidentiality
 
@@ -344,6 +365,8 @@ func (mc *ModifiedConfidentiality) parse(str string) error {
 	return err
 }
 
+/******** MODIFIED INTEGRITY (MI) ********/
+
 type ModifiedIntegrity Integrity
 
 const (
@@ -380,6 +403,8 @@ func (mi *ModifiedIntegrity) parse(str string) error {
 	return err
 }
 
+/******** MODIFIED AVAILABILITY (MA) ********/
+
 type ModifiedAvailability Availability
 
 const (
@@ -413,5 +438,105 @@ func (ma *ModifiedAvailability) parse(str string) error {
 	a := Availability(*ma)
 	err := a.parse(str)
 	*ma = ModifiedAvailability(a)
+	return err
+}
+
+/*
+	EXTENDED FUNCTIONALITY
+	The following metrics extend the CVSS Specification by allowing Temporal
+	metrics to be modified in the Environmental Score.
+	If not used they will not be serialized allowing backwards compatibility.
+*/
+
+/******** MODIFIED EXPLOIT CODE MATURITY (MR) ********/
+
+type ModifiedExploitCodeMaturity ExploitCodeMaturity
+
+const (
+	ModifiedExploitCodeMaturityNotdefined       ModifiedExploitCodeMaturity = 0
+	ModifiedExploitCodeMaturityNotdefinedString string                      = "X"
+)
+
+func (mecm ModifiedExploitCodeMaturity) defined() bool {
+	return ExploitCodeMaturity(mecm).defined()
+}
+
+func (mecm ModifiedExploitCodeMaturity) weight() float64 {
+	if !mecm.defined() {
+		return 1.00
+	}
+	return ExploitCodeMaturity(mecm).weight()
+}
+
+func (mecm ModifiedExploitCodeMaturity) String() string {
+	return ExploitCodeMaturity(mecm).String()
+}
+
+func (mecm *ModifiedExploitCodeMaturity) parse(str string) error {
+	a := ExploitCodeMaturity(*mecm)
+	err := a.parse(str)
+	*mecm = ModifiedExploitCodeMaturity(a)
+	return err
+}
+
+/******** MODIFIED REMEDIATION LEVEL (MRL) ********/
+
+type ModifiedRemediationLevel RemediationLevel
+
+const (
+	ModifiedRemediationLevelNotdefined       ModifiedRemediationLevel = 0
+	ModifiedRemediationLevelNotdefinedString string                   = "X"
+)
+
+func (mrl ModifiedRemediationLevel) defined() bool {
+	return RemediationLevel(mrl).defined()
+}
+
+func (mrl ModifiedRemediationLevel) weight() float64 {
+	if !mrl.defined() {
+		return 1.00
+	}
+	return RemediationLevel(mrl).weight()
+}
+
+func (mrl ModifiedRemediationLevel) String() string {
+	return RemediationLevel(mrl).String()
+}
+
+func (mrl *ModifiedRemediationLevel) parse(str string) error {
+	a := RemediationLevel(*mrl)
+	err := a.parse(str)
+	*mrl = ModifiedRemediationLevel(a)
+	return err
+}
+
+/******** MODIFIED REPORT CONFIDENCE LEVEL (MRC) ********/
+
+type ModifiedReportConfidence ReportConfidence
+
+const (
+	ModifiedReportConfidenceNotdefined       ModifiedReportConfidence = 0
+	ModifiedReportConfidenceNotdefinedString string                   = "X"
+)
+
+func (mrc ModifiedReportConfidence) defined() bool {
+	return ReportConfidence(mrc).defined()
+}
+
+func (mrc ModifiedReportConfidence) weight() float64 {
+	if !mrc.defined() {
+		return 1.00
+	}
+	return ReportConfidence(mrc).weight()
+}
+
+func (mrc ModifiedReportConfidence) String() string {
+	return ReportConfidence(mrc).String()
+}
+
+func (mrc *ModifiedReportConfidence) parse(str string) error {
+	a := ReportConfidence(*mrc)
+	err := a.parse(str)
+	*mrc = ModifiedReportConfidence(a)
 	return err
 }

--- a/cvss3/score.go
+++ b/cvss3/score.go
@@ -75,9 +75,8 @@ func (v Vector) impactScore() float64 {
 			(1-v.BaseMetrics.Availability.weight())
 	if v.baseScopeChanged() {
 		return 7.52*(iscBase-0.029) - 3.25*math.Pow((iscBase-0.02), 15)
-	} else {
-		return 6.42 * iscBase
 	}
+	return 6.42 * iscBase
 }
 
 func (v Vector) exploitabilityScore() float64 {
@@ -107,10 +106,34 @@ func (v Vector) EnvironmentalScore() float64 {
 		c = 1.08
 	}
 
+	modifiedTemporalMetricsMult := v.modifiedTemporalMetricsMult()
+
 	return roundUp(roundUp(math.Min(c*(e+i), 10.0)) *
-		v.TemporalMetrics.ExploitCodeMaturity.weight() *
-		v.TemporalMetrics.RemediationLevel.weight() *
-		v.TemporalMetrics.ReportConfidence.weight())
+		modifiedTemporalMetricsMult)
+}
+
+func (v Vector) modifiedTemporalMetricsMult() float64 {
+	var me, mrl, mrc float64
+
+	if v.EnvironmentalMetrics.ModifiedExploitCodeMaturity.defined() {
+		me = v.EnvironmentalMetrics.ModifiedExploitCodeMaturity.weight()
+	} else {
+		me = v.TemporalMetrics.ExploitCodeMaturity.weight()
+	}
+
+	if v.EnvironmentalMetrics.ModifiedRemediationLevel.defined() {
+		mrl = v.EnvironmentalMetrics.ModifiedRemediationLevel.weight()
+	} else {
+		mrl = v.TemporalMetrics.RemediationLevel.weight()
+	}
+
+	if v.EnvironmentalMetrics.ModifiedReportConfidence.defined() {
+		mrc = v.EnvironmentalMetrics.ModifiedReportConfidence.weight()
+	} else {
+		mrc = v.TemporalMetrics.ReportConfidence.weight()
+	}
+
+	return me * mrl * mrc
 }
 
 func (v Vector) modifiedImpactScore() float64 {

--- a/cvss3/score_test.go
+++ b/cvss3/score_test.go
@@ -107,6 +107,11 @@ func TestScores(t *testing.T) {
 		{"CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:H/A:L/E:P/RL:W/RC:R/CR:M/IR:H/AR:L/MAV:N/MAC:H/MPR:L/MUI:R/MS:C/MC:L/MA:N", 5.1, 4.5, 7.1},
 		{"CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:H/A:L/E:P/RL:W/RC:R/CR:M/IR:H/AR:L/MAV:N/MAC:H/MPR:L/MUI:R/MS:U/MC:L/MA:N", 5.1, 4.5, 6.1},
 		{"CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:H/A:L/E:P/RL:W/RC:R/CR:M/IR:H/AR:L/MAV:N/MAC:H/MPR:L/MUI:R/MS:X/MC:L/MA:N", 5.1, 4.5, 6.1},
+
+		// Extended functionality: defined Modified Temporal metrics should override temporal metrics
+		{"CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:H/A:L/E:P/RL:W/RC:R/CR:M/IR:H/AR:L/MAV:N/MAC:H/MPR:L/MUI:R/MS:X/MC:L/MA:N/ME:F", 5.1, 4.5, 6.3},
+		{"CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:H/A:L/E:P/RL:W/RC:R/CR:M/IR:H/AR:L/MAV:N/MAC:H/MPR:L/MUI:R/MS:X/MC:L/MA:N/MRL:T", 5.1, 4.5, 6.0},
+		{"CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:H/A:L/E:P/RL:W/RC:R/CR:M/IR:H/AR:L/MAV:N/MAC:H/MPR:L/MUI:R/MS:X/MC:L/MA:N/MRC:U", 5.1, 4.5, 5.8},
 	}
 
 	for i, c := range cases {

--- a/cvss3/vector.go
+++ b/cvss3/vector.go
@@ -130,7 +130,7 @@ func (v *Vector) Absorb(other Vector) {
 
 // helpers
 
-var order = []string{"AV", "AC", "PR", "UI", "S", "C", "I", "A", "E", "RL", "RC", "CR", "IR", "AR", "MAV", "MAC", "MPR", "MUI", "MS", "MC", "MI", "MA"}
+var order = []string{"AV", "AC", "PR", "UI", "S", "C", "I", "A", "E", "RL", "RC", "CR", "IR", "AR", "MAV", "MAC", "MPR", "MUI", "MS", "MC", "MI", "MA", "ME", "MRL", "MRC"}
 
 type defineable interface {
 	defined() bool
@@ -168,6 +168,9 @@ func (v *Vector) definables() map[string]defineable {
 		"MC":  v.EnvironmentalMetrics.ModifiedConfidentiality,
 		"MI":  v.EnvironmentalMetrics.ModifiedIntegrity,
 		"MA":  v.EnvironmentalMetrics.ModifiedAvailability,
+		"ME":  v.EnvironmentalMetrics.ModifiedExploitCodeMaturity,
+		"MRL": v.EnvironmentalMetrics.ModifiedRemediationLevel,
+		"MRC": v.EnvironmentalMetrics.ModifiedReportConfidence,
 	}
 }
 
@@ -198,5 +201,8 @@ func (v *Vector) parseables() map[string]parseable {
 		"MC":  &v.EnvironmentalMetrics.ModifiedConfidentiality,
 		"MI":  &v.EnvironmentalMetrics.ModifiedIntegrity,
 		"MA":  &v.EnvironmentalMetrics.ModifiedAvailability,
+		"ME":  &v.EnvironmentalMetrics.ModifiedExploitCodeMaturity,
+		"MRL": &v.EnvironmentalMetrics.ModifiedRemediationLevel,
+		"MRC": &v.EnvironmentalMetrics.ModifiedReportConfidence,
 	}
 }


### PR DESCRIPTION
In the Common Vulnerability Scoring System v3.1: Specification Document, Environmental Score is defined by a formula which depends on *Modified* Base Metrics, Temporal Metrics and 3 other ones: ConfidentialityRequirement, IntegrityRequirement and AvailabilityRequirement.

**This PR allows for Temporal Metrics to also be Modified so that, if they are, its value would override the Temporal Metric one while calculating the Environmental Score**.

So, instead of something like 

```
EnvironmentalScore = Roundup ( Roundup [Minimum ([ModifiedImpact + ModifiedExploitability], 10) ] × ExploitCodeMaturity × RemediationLevel × ReportConfidence)
```

We would have

```
EnvironmentalScore = Roundup ( Roundup [Minimum ([ModifiedImpact + ModifiedExploitability], 10) ] × ModifiedExploitCodeMaturity × ModifiedRemediationLevel × ModifiedReportConfidence)
```

IF DEFINED ONLY, otherwise the original temporal metric value would be used