### PR TITLE
Extend CVSS2 specification: Modified Temporal metrics

### DIFF
--- a/cvss2/environmental_metrics.go
+++ b/cvss2/environmental_metrics.go
@@ -22,6 +22,9 @@ type EnvironmentalMetrics struct {
 	ConfidentialityRequirement
 	IntegrityRequirement
 	AvailabilityRequirement
+	ModifiedExploitablity
+	ModifiedRemediationLevel
+	ModifiedReportConfidence
 }
 
 type CollateralDamagePotential int
@@ -200,4 +203,89 @@ func (ar *AvailabilityRequirement) parse(str string) error {
 		return nil
 	}
 	return fmt.Errorf("illegal availability requirement code %s", str)
+}
+
+/*
+	EXTENDED FUNCTIONALITY
+	The following metrics extend the CVSS Specification by allowing Temporal
+	metrics to be modified in the Environmental Score.
+	If not used they will not be serialized allowing backwards compatibility.
+*/
+
+/******** MODIFIED EXPLOITABILITY (ME) ********/
+
+type ModifiedExploitablity Exploitablity
+
+func (mecm ModifiedExploitablity) defined() bool {
+	return Exploitablity(mecm).defined()
+}
+
+func (mecm ModifiedExploitablity) weight() float64 {
+	if !mecm.defined() {
+		return 1.00
+	}
+	return Exploitablity(mecm).weight()
+}
+
+func (mecm ModifiedExploitablity) String() string {
+	return Exploitablity(mecm).String()
+}
+
+func (mecm *ModifiedExploitablity) parse(str string) error {
+	a := Exploitablity(*mecm)
+	err := a.parse(str)
+	*mecm = ModifiedExploitablity(a)
+	return err
+}
+
+/******** MODIFIED REMEDIATION LEVEL (MRL) ********/
+
+type ModifiedRemediationLevel RemediationLevel
+
+func (mrl ModifiedRemediationLevel) defined() bool {
+	return RemediationLevel(mrl).defined()
+}
+
+func (mrl ModifiedRemediationLevel) weight() float64 {
+	if !mrl.defined() {
+		return 1.00
+	}
+	return RemediationLevel(mrl).weight()
+}
+
+func (mrl ModifiedRemediationLevel) String() string {
+	return RemediationLevel(mrl).String()
+}
+
+func (mrl *ModifiedRemediationLevel) parse(str string) error {
+	a := RemediationLevel(*mrl)
+	err := a.parse(str)
+	*mrl = ModifiedRemediationLevel(a)
+	return err
+}
+
+/******** MODIFIED REPORT CONFIDENCE LEVEL (MRC) ********/
+
+type ModifiedReportConfidence ReportConfidence
+
+func (mrc ModifiedReportConfidence) defined() bool {
+	return ReportConfidence(mrc).defined()
+}
+
+func (mrc ModifiedReportConfidence) weight() float64 {
+	if !mrc.defined() {
+		return 1.00
+	}
+	return ReportConfidence(mrc).weight()
+}
+
+func (mrc ModifiedReportConfidence) String() string {
+	return ReportConfidence(mrc).String()
+}
+
+func (mrc *ModifiedReportConfidence) parse(str string) error {
+	a := ReportConfidence(*mrc)
+	err := a.parse(str)
+	*mrc = ModifiedReportConfidence(a)
+	return err
 }

--- a/cvss2/score_test.go
+++ b/cvss2/score_test.go
@@ -92,21 +92,35 @@ func TestBaseScores(t *testing.T) {
 func TestScores(t *testing.T) {
 	// random vector chosen and validated at:
 	// https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?calculator&adv&version=2
-	v, err := VectorFromString("(AV:A/AC:L/Au:S/C:C/I:P/A:C/E:F/RL:W/RC:UR/CDP:MH/TD:M/CR:M/IR:L/AR:H)")
-	if err != nil {
-		t.Errorf("parse error: %v", err)
+
+	cases := []struct {
+		str           string
+		base          float64
+		temporal      float64
+		environmental float64
+	}{
+		{"(AV:A/AC:L/Au:S/C:C/I:P/A:C/E:F/RL:W/RC:UR/CDP:MH/TD:M/CR:M/IR:L/AR:H)", 7.4, 6.3, 6.0},
+
+		// Extended functionality: defined Modified Temporal metrics should override temporal metrics
+		{"(AV:A/AC:L/Au:S/C:C/I:P/A:C/E:F/RL:W/RC:UR/CDP:MH/TD:M/CR:M/IR:L/AR:H/MRC:UC)", 7.4, 6.3, 5.8},
 	}
 
-	if s := v.BaseScore(); s != 7.4 {
-		t.Errorf("base score expected to be %.1f, got %.1f", 7.4, s)
-	}
-
-	if s := v.TemporalScore(); s != 6.3 {
-		t.Errorf("temporal score expected to be %.1f, got %.1f", 6.3, s)
-	}
-
-	if s := v.EnvironmentalScore(); s != 6.0 {
-		t.Errorf("environmental score expected to be %.1f, got %.1f", 6.0, s)
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %2d", i+1), func(t *testing.T) {
+			v, err := VectorFromString(c.str)
+			if err != nil {
+				t.Errorf("parse error: %v", err)
+			}
+			if vbs := v.BaseScore(); vbs != c.base {
+				t.Errorf("base score expected to be %.1f, got %.1f", c.base, vbs)
+			}
+			if vts := v.TemporalScore(); vts != c.temporal {
+				t.Errorf("temporal score expected to be %.1f, got %.1f", c.temporal, vts)
+			}
+			if ves := v.EnvironmentalScore(); ves != c.environmental {
+				t.Errorf("environmental score expected to be %.1f, got %.1f", c.environmental, ves)
+			}
+		})
 	}
 }
 

--- a/cvss2/vector.go
+++ b/cvss2/vector.go
@@ -98,7 +98,7 @@ func (v *Vector) Absorb(other Vector) {
 
 // helpers
 
-var order = []string{"AV", "AC", "Au", "C", "I", "A", "E", "RL", "RC", "CDP", "TD", "CR", "IR", "AR"}
+var order = []string{"AV", "AC", "Au", "C", "I", "A", "E", "RL", "RC", "CDP", "TD", "CR", "IR", "AR", "ME", "MRL", "MRC"}
 
 type defineable interface {
 	defined() bool
@@ -128,6 +128,10 @@ func (v *Vector) definables() map[string]defineable {
 		"CR":  v.EnvironmentalMetrics.ConfidentialityRequirement,
 		"IR":  v.EnvironmentalMetrics.IntegrityRequirement,
 		"AR":  v.EnvironmentalMetrics.AvailabilityRequirement,
+		// extended environmental metrics
+		"ME":  v.EnvironmentalMetrics.ModifiedExploitablity,
+		"MRL": v.EnvironmentalMetrics.ModifiedRemediationLevel,
+		"MRC": v.EnvironmentalMetrics.ModifiedReportConfidence,
 	}
 }
 
@@ -150,5 +154,9 @@ func (v *Vector) parseables() map[string]parseable {
 		"CR":  &v.EnvironmentalMetrics.ConfidentialityRequirement,
 		"IR":  &v.EnvironmentalMetrics.IntegrityRequirement,
 		"AR":  &v.EnvironmentalMetrics.AvailabilityRequirement,
+		// extended environmental metrics
+		"ME":  &v.EnvironmentalMetrics.ModifiedExploitablity,
+		"MRL": &v.EnvironmentalMetrics.ModifiedRemediationLevel,
+		"MRC": &v.EnvironmentalMetrics.ModifiedReportConfidence,
 	}
 }

--- a/cvss2/vector_test.go
+++ b/cvss2/vector_test.go
@@ -46,6 +46,7 @@ func TestFromString(t *testing.T) {
 		"(AV:A/AC:L/Au:N/C:N/I:N/A:P/E:U/RL:U/RC:C)",
 		"(AV:A/AC:L/Au:S/C:N/I:N/A:C/E:U/RL:OF/RC:C)",
 		"(AV:L/AC:L/Au:S/C:N/I:N/A:P/E:U/RL:OF/RC:C)",
+		"(AV:L/AC:L/Au:S/C:N/I:N/A:P/E:U/RL:OF/RC:C/ME:U/MRL:OF/MRC:C)",
 	}
 
 	for i, str := range cases {
@@ -63,7 +64,7 @@ func TestFromString(t *testing.T) {
 func BenchmarkParse(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		// all possible metrics are defined in this string
-		VectorFromString("CVSS:3.0/AV:P/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:L/E:U/RL:T/RC:R/CR:H/IR:M/AR:L/MAV:P/MAC:H/MPR:L/MUI:R/MS:U/MC:L/MI:L/MA:H")
+		VectorFromString("CVSS:3.0/AV:P/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:L/E:U/RL:T/RC:R/CR:H/IR:M/AR:L/MAV:P/MAC:H/MPR:L/MUI:R/MS:U/MC:L/MI:L/MA:H/ME:U/MRL:OF/MRC:C")
 	}
 }
 


### PR DESCRIPTION
In the Common Vulnerability Scoring System v2: Specification Document, Environmental Score is defined by a formula which depends on General Modifiers, Temporal Metrics and Impact Subscore Modifiers.

This PR allows for Temporal Metrics to also be Modified so that, if they are, its value would override the Temporal Metric one while calculating the Environmental Score.