### PR TITLE
Propagate a context.Context and use errgroups to cancel pending HTTP GETs on error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 dist: xenial
 
 go:
-- '1.10'
+- 1.13
 - 1.x
 - master
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The [HOWTO](HOWTO.md) provides a broader view on how to effectively use these to
 
 ## Requirements
 
-* Go 1.10 or newer
+* Go 1.13 or newer
 
 ## Installation
 

--- a/cmd/fireeye2nvd/fireeye2nvd.go
+++ b/cmd/fireeye2nvd/fireeye2nvd.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -40,7 +41,7 @@ func Read(r io.Reader, c chan runner.Convertible) error {
 	return nil
 }
 
-func FetchSince(c client.Client, baseURL string, since int64) (<-chan runner.Convertible, error) {
+func FetchSince(ctx context.Context, c client.Client, baseURL string, since int64) (<-chan runner.Convertible, error) {
 	publicKey := os.Getenv("FIREEYE_PUBLIC_KEY")
 	if publicKey == "" {
 		return nil, fmt.Errorf("please set FIREEYE_PUBLIC_KEY in environment")
@@ -51,7 +52,7 @@ func FetchSince(c client.Client, baseURL string, since int64) (<-chan runner.Con
 	}
 
 	client := api.NewClient(c, baseURL, publicKey, privateKey)
-	return client.FetchAllVulnerabilities(since)
+	return client.FetchAllVulnerabilities(ctx, since)
 }
 
 func main() {

--- a/cmd/flexera2nvd/flexera2nvd.go
+++ b/cmd/flexera2nvd/flexera2nvd.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -40,14 +41,14 @@ func Read(r io.Reader, c chan runner.Convertible) error {
 	return nil
 }
 
-func FetchSince(c client.Client, baseURL string, since int64) (<-chan runner.Convertible, error) {
+func FetchSince(ctx context.Context, c client.Client, baseURL string, since int64) (<-chan runner.Convertible, error) {
 	apiKey := os.Getenv("FLEXERA_TOKEN")
 	if apiKey == "" {
 		return nil, fmt.Errorf("please set FLEXERA_TOKEN in environment")
 	}
 
 	client := api.NewClient(c, baseURL, apiKey)
-	return client.FetchAllVulnerabilities(since)
+	return client.FetchAllVulnerabilities(ctx, since)
 }
 
 func main() {

--- a/cmd/idefense2nvd/idefense2nvd.go
+++ b/cmd/idefense2nvd/idefense2nvd.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -40,13 +41,13 @@ func Read(r io.Reader, c chan runner.Convertible) error {
 	return nil
 }
 
-func FetchSince(c client.Client, baseURL string, since int64) (<-chan runner.Convertible, error) {
+func FetchSince(ctx context.Context, c client.Client, baseURL string, since int64) (<-chan runner.Convertible, error) {
 	apiKey := os.Getenv("IDEFENSE_TOKEN")
 	if apiKey == "" {
 		return nil, fmt.Errorf("please set IDEFENSE_TOKEN in environment")
 	}
 	client := api.NewClient(c, baseURL, apiKey)
-	return client.FetchAllVulnerabilities(since)
+	return client.FetchAllVulnerabilities(ctx, since)
 }
 
 func main() {

--- a/cmd/rbs2nvd/rbs2nvd.go
+++ b/cmd/rbs2nvd/rbs2nvd.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -48,7 +49,7 @@ func Read(r io.Reader, c chan runner.Convertible) error {
 	return nil
 }
 
-func FetchSince(c client.Client, baseURL string, since int64) (<-chan runner.Convertible, error) {
+func FetchSince(ctx context.Context, c client.Client, baseURL string, since int64) (<-chan runner.Convertible, error) {
 	clientID := os.Getenv("RBS_CLIENT_ID")
 	if clientID == "" {
 		return nil, fmt.Errorf("please set RBS_CLIENT_ID in environment")

--- a/cmd/redhat2nvd/redhat2nvd.go
+++ b/cmd/redhat2nvd/redhat2nvd.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -40,7 +41,7 @@ func Read(r io.Reader, c chan runner.Convertible) error {
 	return nil
 }
 
-func FetchSince(c client.Client, baseURL string, since int64) (<-chan runner.Convertible, error) {
+func FetchSince(ctx context.Context, c client.Client, baseURL string, since int64) (<-chan runner.Convertible, error) {
 	client := api.NewClient(c, baseURL)
 	return client.FetchAllCVEs(since)
 }

--- a/cmd/snyk2nvd/snyk2nvd.go
+++ b/cmd/snyk2nvd/snyk2nvd.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -46,7 +47,7 @@ func Read(r io.Reader, c chan runner.Convertible) error {
 	return nil
 }
 
-func FetchSince(c client.Client, baseURL string, since int64) (<-chan runner.Convertible, error) {
+func FetchSince(ctx context.Context, c client.Client, baseURL string, since int64) (<-chan runner.Convertible, error) {
 	consumerID := os.Getenv("SNYK_ID")
 	if consumerID == "" {
 		return nil, fmt.Errorf("please set SNYK_ID in environment")
@@ -57,7 +58,7 @@ func FetchSince(c client.Client, baseURL string, since int64) (<-chan runner.Con
 	}
 
 	client := api.NewClient(c, baseURL, consumerID, secret)
-	advs, err := client.FetchAllVulnerabilities(since)
+	advs, err := client.FetchAllVulnerabilities(ctx, since)
 	return lf.filter(advs), err
 }
 

--- a/providers/fireeye/api/client.go
+++ b/providers/fireeye/api/client.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -58,11 +59,12 @@ func NewClient(c client.Client, baseURL, publicKey, privateKey string) *Client {
 }
 
 // Request will fetch the given endpoint and return the response
-func (c *Client) Request(endpoint string) (io.Reader, error) {
+func (c *Client) Request(ctx context.Context, endpoint string) (io.Reader, error) {
 	req, err := http.NewRequest("GET", c.baseURL+endpoint, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create http get request")
 	}
+	req = req.WithContext(ctx)
 
 	acceptHeader := "application/json"
 	timestamp := time.Now().Format(time.RFC1123)

--- a/providers/fireeye/api/vulnerability.go
+++ b/providers/fireeye/api/vulnerability.go
@@ -15,6 +15,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -26,7 +27,7 @@ import (
 )
 
 // FetchAllVulnerabilities will fetch all vulnerabilities with specified parameters
-func (c *Client) FetchAllVulnerabilities(since int64) (<-chan runner.Convertible, error) {
+func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-chan runner.Convertible, error) {
 	parameters := newParametersSince(since)
 	if err := parameters.validate(); err != nil {
 		return nil, err
@@ -41,7 +42,7 @@ func (c *Client) FetchAllVulnerabilities(since int64) (<-chan runner.Convertible
 		go func() {
 			defer wg.Done()
 			log.Printf("Fetching: %s\n", params)
-			vs, err := c.fetchVulnerabilities(params)
+			vs, err := c.fetchVulnerabilities(ctx, params)
 			if err != nil {
 				log.Printf("error while fetching %s: %v", params, err)
 				return
@@ -63,8 +64,8 @@ func (c *Client) FetchAllVulnerabilities(since int64) (<-chan runner.Convertible
 	return output, nil
 }
 
-func (c *Client) fetchVulnerabilities(parameters timeRangeParameters) ([]*schema.Vulnerability, error) {
-	resp, err := c.Request(fmt.Sprintf("/view/vulnerability?%s", parameters.query()))
+func (c *Client) fetchVulnerabilities(ctx context.Context, parameters timeRangeParameters) ([]*schema.Vulnerability, error) {
+	resp, err := c.Request(ctx, fmt.Sprintf("/view/vulnerability?%s", parameters.query()))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/fireeye/api/vulnerability.go
+++ b/providers/fireeye/api/vulnerability.go
@@ -21,6 +21,7 @@ import (
 	"log"
 
 	"github.com/facebookincubator/nvdtools/providers/fireeye/schema"
+	"github.com/facebookincubator/nvdtools/providers/lib/client"
 	"github.com/facebookincubator/nvdtools/providers/lib/runner"
 	"github.com/facebookincubator/nvdtools/stats"
 	"golang.org/x/sync/errgroup"
@@ -42,7 +43,7 @@ func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-ch
 			log.Printf("Fetching: %s\n", params)
 			vs, err := c.fetchVulnerabilities(ctx, params)
 			if err != nil {
-				return fmt.Errorf("error while fetching %s: %v", params, err)
+				return client.StopOrContinue(fmt.Errorf("error while fetching %s: %v", params, err))
 			}
 			numVulns := len(vs)
 			log.Printf("Adding %d vulns\n", numVulns)

--- a/providers/fireeye/api/vulnerability.go
+++ b/providers/fireeye/api/vulnerability.go
@@ -19,11 +19,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"sync"
 
 	"github.com/facebookincubator/nvdtools/providers/fireeye/schema"
 	"github.com/facebookincubator/nvdtools/providers/lib/runner"
 	"github.com/facebookincubator/nvdtools/stats"
+	"golang.org/x/sync/errgroup"
 )
 
 // FetchAllVulnerabilities will fetch all vulnerabilities with specified parameters
@@ -34,18 +34,15 @@ func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-ch
 	}
 
 	output := make(chan runner.Convertible)
-	wg := sync.WaitGroup{}
 
+	eg, ctx := errgroup.WithContext(ctx)
 	for _, params := range parameters.batchBy(ninetyDays) {
 		params := params
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		eg.Go(func() error {
 			log.Printf("Fetching: %s\n", params)
 			vs, err := c.fetchVulnerabilities(ctx, params)
 			if err != nil {
-				log.Printf("error while fetching %s: %v", params, err)
-				return
+				return fmt.Errorf("error while fetching %s: %v", params, err)
 			}
 			numVulns := len(vs)
 			log.Printf("Adding %d vulns\n", numVulns)
@@ -53,12 +50,15 @@ func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-ch
 			for _, v := range vs {
 				output <- v
 			}
-		}()
+			return nil
+		})
 	}
 
 	go func() {
-		defer close(output)
-		wg.Wait()
+		if err := eg.Wait(); err != nil {
+			log.Println(err)
+		}
+		close(output)
 	}()
 
 	return output, nil

--- a/providers/flexera/api/client.go
+++ b/providers/flexera/api/client.go
@@ -79,7 +79,7 @@ func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-ch
 		identifersEg.Go(func() error {
 			list, err := c.fetchAdvisoryList(identifiersCtx, from, to, p)
 			if err != nil {
-				return errors.Wrapf(err, "failed to fetch page %d advisory list", p)
+				return client.StopOrContinue(errors.Wrapf(err, "failed to fetch page %d advisory list", p))
 			}
 			for _, element := range list.Results {
 				identifiers <- element.AdvisoryIdentifier
@@ -102,7 +102,7 @@ func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-ch
 			for identifier := range identifiers {
 				advisory, err := c.Fetch(advisoriesCtx, identifier)
 				if err != nil {
-					return errors.Wrapf(err, "failed to fetch advisory %s", identifier)
+					return client.StopOrContinue(errors.Wrapf(err, "failed to fetch advisory %s", identifier))
 				}
 				advisories <- advisory
 			}

--- a/providers/idefense/api/client.go
+++ b/providers/idefense/api/client.go
@@ -85,7 +85,7 @@ func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-ch
 				"page":                    page,
 			})
 			if err != nil {
-				return errors.Wrapf(err, "failed to get page %d: %v", page, err)
+				return client.StopOrContinue(errors.Wrapf(err, "failed to get page %d: %v", page, err))
 			}
 			for _, vuln := range result.Results {
 				if vuln != nil {

--- a/providers/idefense/api/client.go
+++ b/providers/idefense/api/client.go
@@ -15,6 +15,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -51,10 +52,10 @@ func NewClient(c client.Client, baseUrl, apiKey string) *Client {
 }
 
 // FetchAllVulnerabilities will fetch all vulnerabilities from iDefense API
-func (c *Client) FetchAllVulnerabilities(since int64) (<-chan runner.Convertible, error) {
+func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-chan runner.Convertible, error) {
 	sinceStr := time.Unix(since, 0).Format("2006-01-02T15:04:05.000Z")
 
-	result, err := c.queryVulnerabilities(map[string]interface{}{
+	result, err := c.queryVulnerabilities(ctx, map[string]interface{}{
 		"last_modified.from":      sinceStr,
 		"last_modified.inclusive": "true",
 		"page_size":               0,
@@ -79,7 +80,7 @@ func (c *Client) FetchAllVulnerabilities(since int64) (<-chan runner.Convertible
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			result, err := c.queryVulnerabilities(map[string]interface{}{
+			result, err := c.queryVulnerabilities(ctx, map[string]interface{}{
 				"last_modified.from":      sinceStr,
 				"last_modified.inclusive": "true",
 				"page_size":               pageSize,
@@ -105,7 +106,7 @@ func (c *Client) FetchAllVulnerabilities(since int64) (<-chan runner.Convertible
 	return output, nil
 }
 
-func (c *Client) queryVulnerabilities(params map[string]interface{}) (*schema.VulnerabilitySearchResults, error) {
+func (c *Client) queryVulnerabilities(ctx context.Context, params map[string]interface{}) (*schema.VulnerabilitySearchResults, error) {
 	u, err := url.Parse(c.baseUrl + vulnerabilityEndpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse url")
@@ -116,7 +117,7 @@ func (c *Client) queryVulnerabilities(params map[string]interface{}) (*schema.Vu
 	}
 	u.RawQuery = query.Encode()
 
-	resp, err := client.Get(c, u.String(), http.Header{
+	resp, err := client.Get(ctx, c, u.String(), http.Header{
 		"Auth-Token": {c.apiKey},
 	})
 	if err != nil {

--- a/providers/lib/client/client.go
+++ b/providers/lib/client/client.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -31,8 +32,8 @@ func Default() Client {
 }
 
 // Get will create a GET request with given headers and call Do on the client
-func Get(c Client, url string, header http.Header) (*http.Response, error) {
-	req, err := http.NewRequest("GET", url, nil)
+func Get(ctx context.Context, c Client, url string, header http.Header) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create http get request: %v", err)
 	}

--- a/providers/lib/client/client.go
+++ b/providers/lib/client/client.go
@@ -40,6 +40,13 @@ func Get(ctx context.Context, c Client, url string, header http.Header) (*http.R
 	req.Header = header
 
 	id := traceRequestStart(req)
+	if debug.failRequestNum == id {
+		return nil, &Err{
+			Code:   503,
+			Status: "Service Unavailable",
+			Body:   "Request cancelled by debug feature",
+		}
+	}
 	resp, err := c.Do(req)
 	traceRequestEnd(id, resp)
 

--- a/providers/lib/client/client.go
+++ b/providers/lib/client/client.go
@@ -39,7 +39,11 @@ func Get(ctx context.Context, c Client, url string, header http.Header) (*http.R
 	}
 	req.Header = header
 
-	return c.Do(req)
+	id := traceRequestStart(req)
+	resp, err := c.Do(req)
+	traceRequestEnd(id, resp)
+
+	return resp, err
 }
 
 // Err encapsulates stuff from the http.Response

--- a/providers/lib/client/debug.go
+++ b/providers/lib/client/debug.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"strconv"
+	"sync/atomic"
+)
+
+var debug struct {
+	// Print HTTP requests and responses to stderr.
+	traceRequests bool
+
+	requestNum uint64
+}
+
+func getBool(varName string) bool {
+	v, _ := strconv.ParseBool(os.Getenv(varName))
+	return v
+}
+
+func init() {
+	debug.traceRequests = getBool("NVD_TRACE_REQUESTS")
+}
+
+func traceRequestStart(req *http.Request) uint64 {
+	if !debug.traceRequests {
+		return 0
+	}
+	id := atomic.AddUint64(&debug.requestNum, 1)
+	data, _ := httputil.DumpRequest(req, false)
+	fmt.Fprintf(os.Stderr, "Req %d: %s", id, string(data))
+	return id
+}
+
+func traceRequestEnd(id uint64, resp *http.Response) {
+	if !debug.traceRequests {
+		return
+	}
+	if resp == nil {
+		return
+	}
+	data, _ := httputil.DumpResponse(resp, false)
+	fmt.Fprintf(os.Stderr, "Req %d: %s", id, string(data))
+}

--- a/providers/lib/client/debug.go
+++ b/providers/lib/client/debug.go
@@ -17,6 +17,8 @@ var debug struct {
 	// cancel pending requests as soon as one request fails. This option
 	// restores the old behaviour or executing the remaning requests anyway.
 	continueDownloading bool
+	// When set to a number n, the n th HTTP request will fail.
+	failRequestNum uint64
 
 	requestNum uint64
 }
@@ -26,9 +28,18 @@ func getBool(varName string) bool {
 	return v
 }
 
+func getUint(varName string, defaultValue uint64) uint64 {
+	v, err := strconv.ParseUint(os.Getenv(varName), 10, 64)
+	if err != nil {
+		return defaultValue
+	}
+	return v
+}
+
 func init() {
 	debug.traceRequests = getBool("NVD_TRACE_REQUESTS")
 	debug.continueDownloading = getBool("NVD_CONTINUE_DOWNLOADING")
+	debug.failRequestNum = getUint("NVD_FAIL_REQUEST", 0)
 }
 
 func obfuscateHeaders(req *http.Request) *http.Request {


### PR DESCRIPTION
This PR enables clean cancellation of pending HTTP requests in 3 providers:

- Propagates a `context.Context` from the `Runner` to `client.Get`
- Modify the concurrent HTTP fetching code in idefense, fireeye and flexera to use errgroup
- BONUS! I've added an HTTP request tracer that was handy to debug what the tools were doing. Users of the client package will automatically inherit this capability, another good reason to push for all tools to use the client package.
   ```
   Req 1: GET /api/advisories?modified__gte=1579615394&modified__lt=1579622594&page_size=1          HTTP/1.1
   Host: api.app.secunia.com
   Authorization: Token xxx

   Req 1: HTTP/1.1 200 OK

   2020/01/21 16:03:15 client.go:71: starting sync for 4 advisories over 1 pages
   Req 2: GET /api/advisories?modified__gte=1579615394&modified__lt=1579622594&page=1&page_size=100 HTTP/1.1
   Host: api.app.secunia.com
   Authorization: Token xxx

   Req 2: HTTP/1.1 200 OK

   Req 3: GET /api/advisories/SA93059 HTTP/1.1
   Host: api.app.secunia.com
   Authorization: Token xxx

   Req 4: GET /api/advisories/SA93070 HTTP/1.1
   Host: api.app.secunia.com
   Authorization: Token xxx

   Req 5: GET /api/advisories/SA92909 HTTP/1.1
   Host: api.app.secunia.com
   Authorization: Token xxx

   Req 6: GET /api/advisories/SA92924 HTTP/1.1
   Host: api.app.secunia.com
   Authorization: Token xxx

   Req 6: HTTP/1.1 200 OK

   Req 4: HTTP/1.1 200 OK

   Req 3: HTTP/1.1 200 OK

   Req 5: HTTP/1.1 200 OK
   ```

**Testing**

```
flexera2nvd -download -since 2h
fireeye2nvd -download --since 48h

```