### PR TITLE
client: Always return a valid request id even if tracing is disabled

### DIFF
--- a/providers/lib/client/debug.go
+++ b/providers/lib/client/debug.go
@@ -81,10 +81,10 @@ func obfuscateHeaders(req *http.Request) *http.Request {
 }
 
 func traceRequestStart(req *http.Request) uint64 {
-	if !debug.traceRequests {
-		return 0
-	}
 	id := atomic.AddUint64(&debug.requestNum, 1)
+	if !debug.traceRequests {
+		return id
+	}
 	data, _ := httputil.DumpRequest(obfuscateHeaders(req), false)
 	fmt.Fprintf(os.Stderr, "Req %d: %s", id, string(data))
 	return id


### PR DESCRIPTION
The http failure injection code uses the request number to decide if it should
fail a request or not. Request numbers start at 1. 0 is never assigned as a
request number and 0 is used to mean "no fault injection".

Unfortunatly, traceRequestStart was returning 0 when tracing was disabled,
which meant that, under normal usage, all requests were triggering the fault
injection code. Argh!