### PR TITLE
Use a context.Context for GET requests

### DIFF
--- a/cmd/redhat2nvd/redhat2nvd.go
+++ b/cmd/redhat2nvd/redhat2nvd.go
@@ -43,7 +43,7 @@ func Read(r io.Reader, c chan runner.Convertible) error {
 
 func FetchSince(ctx context.Context, c client.Client, baseURL string, since int64) (<-chan runner.Convertible, error) {
 	client := api.NewClient(c, baseURL)
-	return client.FetchAllCVEs(since)
+	return client.FetchAllCVEs(ctx, since)
 }
 
 func main() {

--- a/providers/redhat/api/client.go
+++ b/providers/redhat/api/client.go
@@ -104,7 +104,7 @@ func (c *Client) fetchAllPages(since int64) <-chan *schema.CVEList {
 					break
 				}
 			} else {
-				log.Printf("can't fecth page %d: %v", page, err)
+				log.Printf("can't fetch page %d: %v", page, err)
 				break
 			}
 		}


### PR DESCRIPTION
This PR propagates a context in the redhat provider and uses the new context-aware client.Get() code path.