### PR TITLE
Enable some static checking with golangci-lint and fixes a few problems found by the tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: go
 dist: xenial
 
-go:
-- 1.13
-- 1.x
-- master
+jobs:
+  include:
+  - go: 1.13
+  - go: 1.x
+  - go: master
+  allow_failures:
+  - go: master
 
 services:
   mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 
 script:
 - go get -v -t -u -d ./...
-- golangci-lint run ./... --disable-all -E gosimple -E govet -E ineffassign -E staticcheck -E structcheck -E typecheck -E varcheck
+- golangci-lint run ./... --disable-all -E gosimple -E govet -E ineffassign -E staticcheck -E structcheck -E varcheck
 - go test -v ./...
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,14 @@ services:
 before_install:
 - sudo apt-get install -y rpm build-essential debhelper dh-make fakeroot zip
 - mysql -e 'CREATE DATABASE vulndb;'
+- curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
 
 env:
 - MYSQL_TEST_DSN=root@/vulndb
 
 script:
 - go get -v -t -u -d ./...
+- golangci-lint run ./... --disable-all -E gosimple -E govet -E ineffassign -E staticcheck -E structcheck -E typecheck -E varcheck
 - go test -v ./...
 
 before_deploy:

--- a/cmd/cpe2cve/config.go
+++ b/cmd/cpe2cve/config.go
@@ -59,8 +59,6 @@ type config struct {
 	// feeds
 	FeedOverrides multiString // []string
 	Feeds         map[string][]string
-
-	provider string
 }
 
 func (cfg *config) addFlags() {

--- a/cmd/rbs2nvd/rbs2nvd.go
+++ b/cmd/rbs2nvd/rbs2nvd.go
@@ -30,8 +30,7 @@ import (
 )
 
 const (
-	baseURL   = "https://vulndb.cyberriskanalytics.com"
-	userAgent = "rbs2nvd"
+	baseURL = "https://vulndb.cyberriskanalytics.com"
 )
 
 var tokenURL = baseURL + "/oauth/token"

--- a/providers/redhat/api/client.go
+++ b/providers/redhat/api/client.go
@@ -37,8 +37,7 @@ const (
 // Client struct
 type Client struct {
 	client.Client
-	baseURL   string
-	userAgent string
+	baseURL string
 }
 
 // NewClient creates an object which is used to query the RedHat API

--- a/providers/redhat/schema/schema.go
+++ b/providers/redhat/schema/schema.go
@@ -29,7 +29,7 @@ type CVEList []struct {
 
 type CVE struct {
 	Name           string `json:"name,omitempty"`
-	ThreatSeverity string `json:"threat_severity,omitempty,omitempty"`
+	ThreatSeverity string `json:"threat_severity,omitempty"`
 	PublicDate     string `json:"public_date,omitempty"`
 	Bugzilla       *struct {
 		Description string `json:"description,omitempty"`
@@ -59,7 +59,7 @@ type CVE struct {
 	// the types of these are just helper types
 
 	AffectedRelease AffectedReleases `json:"affected_release,omitempty"`
-	PackageState    PackageStates    `json:"package_state,omittempty"`
+	PackageState    PackageStates    `json:"package_state,omitempty"`
 }
 
 type AffectedRelease struct {

--- a/rpm/rpm2wfn.go
+++ b/rpm/rpm2wfn.go
@@ -22,7 +22,6 @@ import (
 
 // FromRPMName parses CPE name from RPM package name
 func ToWFN(attr *wfn.Attributes, s string) error {
-	var err error
 	pkg, err := Parse(s)
 	if err != nil {
 		return fmt.Errorf("can't get fields from %q: %v", s, err)
@@ -35,7 +34,7 @@ func ToWFN(attr *wfn.Attributes, s string) error {
 		"arch":    &pkg.Arch,
 	} {
 		if *addr, err = wfn.WFNize(*addr); err != nil {
-			err = fmt.Errorf("couldn't wfnize %s %q: %v", n, *addr, err)
+			return fmt.Errorf("couldn't wfnize %s %q: %v", n, *addr, err)
 		}
 	}
 


### PR DESCRIPTION
Nothing too major found:

- Errors weren't propagated in `rpm.ToWFN`
- Some misspelled json struct tags
- Some unused fields

I've disabled a few default linting passes, more notably `errcheck`: there are many code path where we don't check and propagate errors. This will have to be a task for another time.