### PR TITLE
[redhat] Fix parsing of time with time zone indicator

### DIFF
--- a/providers/redhat/schema/convertutils.go
+++ b/providers/redhat/schema/convertutils.go
@@ -36,7 +36,10 @@ var (
 )
 
 func convertTime(redhatTime string) (string, error) {
-	t, err := time.Parse(timeLayout, redhatTime)
+	t, err := time.Parse(time.RFC3339, redhatTime)
+	if err != nil {
+		t, err = time.Parse(timeLayout, redhatTime)
+	}
 	if err != nil { // should be parsable
 		log.Printf("unable to parse time: %v", err)
 		return redhatTime, err

--- a/providers/redhat/schema/convertutils_test.go
+++ b/providers/redhat/schema/convertutils_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestConvertTime(t *testing.T) {
+	for i, test := range []struct {
+		input, expected string
+	}{
+		{"2006-01-02T15:04:05", "2006-01-02T15:04Z"},
+		{"2006-01-02T15:04:05Z", "2006-01-02T15:04Z"},
+	} {
+		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+			if got, _ := convertTime(test.input); got != test.expected {
+				t.Fatalf("expected %s, got %s", test.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The upstream feed must have changed recently, adding the Z at the end of the
time string. We had a wall of:

```
$ redhat2nvd -download -convert -since 240h > redhat-nvd.json
[...]
2020/01/28 11:23:23 convertutils.go:41: unable to parse time: parsing time "2020-01-22T00:00:00Z": extra text: Z
2020/01/28 11:23:23 main.go:162: error while converting vuln: unable to convert published date: parsing time "2020-01-22T00:00:00Z": extra text: Z
```

This error was preventing CVE entries from being converted and those entries
weren't present in the final NVD feed.