### PR TITLE
[redhat] Add the ability to list non applicable CVEs for a given package

### DIFF
--- a/cmd/redhat_query/fixed-cves.go
+++ b/cmd/redhat_query/fixed-cves.go
@@ -1,0 +1,62 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/facebookincubator/nvdtools/providers/redhat"
+	"github.com/pkg/errors"
+
+	"github.com/spf13/cobra"
+)
+
+var fixedCVEsCmd = &cobra.Command{
+	Use:   "fixed-cves PACKAGENAME [PACKAGENAME...]",
+	Short: "list the fixed/non applicable CVEs for a given package",
+	RunE:  fixedCVEs,
+}
+
+func init() {
+	rootCmd.AddCommand(fixedCVEsCmd)
+}
+
+func fixedCVEs(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return errors.New("fixed-cves: missing package name(s)")
+	}
+
+	feed, err := redhat.LoadFeed(options.feed)
+	if err != nil {
+		return errors.Wrap(err, "fixed-cves")
+	}
+
+	for _, pkg := range args {
+		cves, err := feed.ListFixedCVEs(options.distro, pkg)
+		if err != nil {
+			return errors.Wrap(err, "fixed-cves")
+		}
+
+		if len(cves) == 0 {
+			fmt.Printf("%s: <no fixed CVE found>\n", pkg)
+			continue
+		}
+
+		fmt.Printf("%s: %s\n", pkg, strings.Join(cves, ","))
+	}
+
+	return nil
+}

--- a/cmd/redhat_query/main.go
+++ b/cmd/redhat_query/main.go
@@ -1,0 +1,47 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var options struct {
+	feed   string
+	distro string
+}
+
+var rootCmd = &cobra.Command{
+	Use:           "redhat_query",
+	Short:         "redhat_query performs various queries on the redhat CVE feed",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVarP(&options.feed, "feed", "f", "redhat-feed.json", "path to the feed JSON file as retrieved by redhat2nvd")
+	rootCmd.PersistentFlags().StringVarP(&options.distro, "distribution", "d", "cpe:/o:redhat:enterprise_linux:7", "CPE identifying the distribution")
+	rootCmd.MarkFlagRequired("feed")
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/providers/redhat/feed.go
+++ b/providers/redhat/feed.go
@@ -26,8 +26,10 @@ import (
 	"github.com/facebookincubator/nvdtools/wfn"
 )
 
+// Feed is a map of CVEs as returned by the redhat API, keyed by CVE names.
 type Feed map[string]*schema.CVE
 
+// LoadFeed loads a Feed from a JSON file.
 func LoadFeed(path string) (Feed, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -45,6 +47,7 @@ func loadFeed(r io.Reader) (Feed, error) {
 	return feed, nil
 }
 
+// Checker returns an rpm.Checker that uses the Feed.
 func (feed Feed) Checker() (rpm.Checker, error) {
 	mc := make(mapChecker, len(feed))
 	var err error

--- a/providers/redhat/feed.go
+++ b/providers/redhat/feed.go
@@ -30,6 +30,8 @@ import (
 type Feed struct {
 	// data is map of CVEs as returned by the redhat API, keyed by CVE names.
 	data map[string]*schema.CVE
+	// pkgCVE is a package -> CVE map produced from data and cached.
+	pkg2CVE packageFeed
 }
 
 // LoadFeed loads a Feed from a JSON file.

--- a/providers/redhat/package_feed.go
+++ b/providers/redhat/package_feed.go
@@ -1,0 +1,118 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redhat
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/facebookincubator/nvdtools/providers/redhat/schema"
+	"github.com/facebookincubator/nvdtools/rpm"
+	"github.com/facebookincubator/nvdtools/wfn"
+	"github.com/pkg/errors"
+)
+
+// packageFeed is an association between package names and the list of CVEs,
+// fixed or not, that have been recording against that package.
+// Packages are identified by their base package names without any epoch,
+// version, release.
+type packageFeed map[string][]*schema.CVE
+
+// addPackage adds pkg to the list of packages only if not already there.
+func addPackage(pkgs []string, pkg string) []string {
+	for _, p := range pkgs {
+		if p == pkg {
+			return pkgs
+		}
+	}
+	return append(pkgs, pkg)
+}
+
+// packageFeed transforms a Feed into a packageFeed.
+func (feed *Feed) packageFeed() packageFeed {
+	if feed.pkg2CVE != nil {
+		return feed.pkg2CVE
+	}
+
+	pkgFeed := packageFeed{}
+
+	for _, cve := range feed.data {
+		var pkgs []string
+
+		// 1. look at AffectedRelease.
+		for _, ar := range cve.AffectedRelease {
+			if ar.Package == "" {
+				continue
+			}
+			// Failing to parse a package isn't fatal, but we want to surface the error
+			rpmPkg, err := rpm.Parse(ar.Package)
+			if err != nil {
+				log.Printf("feed: failed to parse package: %q", ar.Package)
+				continue
+			}
+			pkgs = addPackage(pkgs, rpmPkg.Name)
+		}
+
+		// 2. look at PackageState.
+		for _, ps := range cve.PackageState {
+			if ps.PackageName == "" {
+				continue
+			}
+			pkgs = addPackage(pkgs, ps.PackageName)
+
+		}
+
+		for _, pkg := range pkgs {
+			pkgFeed[pkg] = append(pkgFeed[pkg], cve)
+
+		}
+	}
+
+	feed.pkg2CVE = pkgFeed
+
+	return pkgFeed
+}
+
+// ListFixedCVEs will return the list of CVEs that aren't applicable for the
+// given (distro, package). Those CVEs could be not applicable for various
+// reasons. For instance for packaged version isn't vulnerable or a fix has
+// been backported.
+// distro is a CPE identifying a distribution.
+// pkg is the full package name as reported, for instance by rpm -qa.
+func (feed *Feed) ListFixedCVEs(distro, pkg string) ([]string, error) {
+	d, err := wfn.Parse(distro)
+	if err != nil {
+		return nil, fmt.Errorf("list: can't parse distro cpe %q: %v", distro, err)
+	}
+	p, err := rpm.Parse(pkg)
+	if err != nil {
+		return nil, fmt.Errorf("list: can't parse package name %q: %v", pkg, err)
+	}
+
+	pkgFeed := feed.packageFeed()
+	checker, err := feed.Checker()
+	if err != nil {
+		return nil, errors.Wrapf(err, "list")
+	}
+
+	var cves []string
+	for _, cve := range pkgFeed[p.Name] {
+		if checker.Check(p, d, cve.Name) {
+			cves = append(cves, cve.Name)
+		}
+	}
+
+	return cves, nil
+}

--- a/providers/redhat/package_feed_test.go
+++ b/providers/redhat/package_feed_test.go
@@ -1,0 +1,282 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redhat
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// package name -> list of CVEs
+type summary map[string][]string
+
+func feedSummary(feed packageFeed) summary {
+	var s summary = make(summary)
+	for pkg, cves := range feed {
+		var cveNames []string
+		for _, cve := range cves {
+			cveNames = append(cveNames, cve.Name)
+		}
+		s[pkg] = cveNames
+	}
+	return s
+
+}
+
+func testFeed(t *testing.T, cves ...string) *Feed {
+	feedJSON := "{" + strings.Join(cves, ",") + "}"
+	feed, err := loadFeed(strings.NewReader(feedJSON))
+	if err != nil {
+		t.Fatalf("failed to parse JSON: %v: %s", err, feedJSON)
+	}
+	return feed
+}
+
+const CVEMultiplePackages = `
+"CVE-2020-7211": {
+	"name": "CVE-2020-7211",
+	"threat_severity": "Low",
+	"public_date": "2019-12-30T00:00:00Z",
+	"bugzilla": {
+		"description": "CVE-2020-7211 QEMU: Slirp: potential directory traversal using relative paths via tftp server on Windows host",
+		"id": "1792130",
+		"url": "https://bugzilla.redhat.com/show_bug.cgi?id=1792130"
+	},
+	"CVSS3": {
+		"cvss3_base_score": "3.8",
+		"cvss3_scoring_vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:L/I:N/A:N",
+		"status": "draft"
+	},
+	"cwe": "CWE-22",
+	"details": [
+		"tftp.c in libslirp 4.1.0, as used in QEMU 4.2.0, does not prevent ..\\ directory traversal on Windows.",
+		"A potential directory traversal issue was found in the tftp server of the SLiRP user-mode networking implementation used by QEMU. It could occur on a Windows host, as it allows the use of both forward ('/') and backward slash('\\') tokens as separators in a file path. A user able to access the tftp server could use this flaw to access undue files by using relative paths."
+	],
+	"references": [
+		"https://www.voidsecurity.in/2019/01/virtualbox-tftp-server-pxe-boot.html"
+	],
+	"acknowledgement": "Red Hat would like to thank Reno Robert for reporting this issue.",
+	"package_state": [
+		{
+			"product_name": "Red Hat Enterprise Linux 7",
+			"fix_state": "Not affected",
+			"package_name": "qemu-kvm-ma",
+			"cpe": "cpe:/o:redhat:enterprise_linux:7"
+		},
+		{
+			"product_name": "Red Hat Enterprise Linux 7",
+			"fix_state": "Not affected",
+			"package_name": "qemu-kvm",
+			"cpe": "cpe:/o:redhat:enterprise_linux:7"
+		},
+		{
+			"product_name": "Red Hat Enterprise Linux 7",
+			"fix_state": "Not affected",
+			"package_name": "qemu-kvm-rhev",
+			"cpe": "cpe:/o:redhat:enterprise_linux:7"
+		},
+		{
+			"product_name": "Red Hat Enterprise Linux 7",
+			"fix_state": "Not affected",
+			"package_name": "slirp4netns",
+			"cpe": "cpe:/o:redhat:enterprise_linux:7"
+		}
+	]
+}
+`
+
+const CVENoPackageState = `
+"CVE-2020-6377": {
+	"name": "CVE-2020-6377",
+	"threat_severity": "Important",
+	"public_date": "2020-01-07T00:00:00Z",
+	"bugzilla": {
+		"description": "CVE-2020-6377 chromium-browser: Use after free in audio",
+		"id": "1789441",
+		"url": "https://bugzilla.redhat.com/show_bug.cgi?id=1789441"
+	},
+	"CVSS3": {
+		"cvss3_base_score": "8.8",
+		"cvss3_scoring_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+		"status": "verified"
+	},
+	"cwe": "CWE-416",
+	"details": [
+		"Use after free in audio in Google Chrome prior to 79.0.3945.117 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page."
+	],
+	"references": [
+		"https://chromereleases.googleblog.com/2020/01/stable-channel-update-for-desktop.html"
+	],
+	"upstream_fix": "chromium-browser 79.0.3945.117",
+	"affected_release": [
+		{
+			"product_name": "Red Hat Enterprise Linux 6 Supplementary",
+			"release_date": "2020-01-13T00:00:00Z",
+			"advisory": "RHSA-2020:0084",
+			"package": "chromium-browser-79.0.3945.117-1.el6_10",
+			"cpe": "cpe:/a:redhat:rhel_extras:6"
+		}
+	],
+	"package_state": null
+}
+`
+
+const CVEAffectedReleaseAndPackageState = `
+"CVE-2019-11745": {
+	"name": "CVE-2019-11745",
+	"threat_severity": "Important",
+	"public_date": "2019-11-21T00:00:00Z",
+	"bugzilla": {
+		"description": "CVE-2019-11745 nss: Out-of-bounds write when passing an output buffer smaller than the block size to NSC_EncryptUpdate",
+		"id": "1774831",
+		"url": "https://bugzilla.redhat.com/show_bug.cgi?id=1774831"
+	},
+	"CVSS3": {
+		"cvss3_base_score": "8.1",
+		"cvss3_scoring_vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+		"status": "verified"
+	},
+	"cwe": "CWE-787",
+	"details": [
+		"When encrypting with a block cipher, if a call to NSC_EncryptUpdate was made with data smaller than the block size, a small out of bounds write could occur. This could have caused heap corruption and a potentially exploitable crash. This vulnerability affects Thunderbird < 68.3, Firefox ESR < 68.3, and Firefox < 71.",
+		"A heap-based buffer overflow was found in the NSC_EncryptUpdate() function in Mozilla nss. A remote attacker could trigger this flaw via SRTP encrypt or decrypt operations, to execute arbitrary code with the permissions of the user running the application (compiled with nss). While the attack complexity is high, the impact to confidentiality, integrity, and availability are high as well."
+	],
+	"references": [
+		"https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_3.44.3_release_notes\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_3.47.1_release_notes"
+	],
+	"acknowledgement": "Red Hat would like to thank the Mozilla Project for reporting this issue.",
+	"upstream_fix": "nss 3.44.3, nss 3.47.1",
+	"affected_release": [
+		{
+			"product_name": "Red Hat Enterprise Linux 6",
+			"release_date": "2019-12-10T00:00:00Z",
+			"advisory": "RHSA-2019:4152",
+			"package": "nss-softokn-3.44.0-6.el6_10",
+			"cpe": "cpe:/o:redhat:enterprise_linux:6"
+		},
+		{
+			"product_name": "Red Hat Enterprise Linux 7",
+			"release_date": "2019-12-10T00:00:00Z",
+			"advisory": "RHSA-2019:4190",
+			"package": "nss-3.44.0-7.el7_7",
+			"cpe": "cpe:/o:redhat:enterprise_linux:7"
+		},
+		{
+			"product_name": "Red Hat Enterprise Linux 8",
+			"release_date": "2019-12-09T00:00:00Z",
+			"advisory": "RHSA-2019:4114",
+			"package": "nss-3.44.0-9.el8_1",
+			"cpe": "cpe:/a:redhat:enterprise_linux:8"
+		}
+	],
+	"package_state": [
+		{
+			"product_name": "Red Hat Enterprise Linux 5",
+			"fix_state": "Not affected",
+			"package_name": "thunderbird",
+			"cpe": "cpe:/o:redhat:enterprise_linux:5"
+		},
+		{
+			"product_name": "Red Hat Enterprise Linux 5",
+			"fix_state": "Not affected",
+			"package_name": "firefox",
+			"cpe": "cpe:/o:redhat:enterprise_linux:5"
+		},
+		{
+			"product_name": "Red Hat Enterprise Linux 5",
+			"fix_state": "Out of support scope",
+			"package_name": "nss",
+			"cpe": "cpe:/o:redhat:enterprise_linux:5"
+		},
+		{
+			"product_name": "Red Hat Enterprise Linux 6",
+			"fix_state": "Not affected",
+			"package_name": "firefox",
+			"cpe": "cpe:/o:redhat:enterprise_linux:6"
+		},
+		{
+			"product_name": "Red Hat Enterprise Linux 6",
+			"fix_state": "Not affected",
+			"package_name": "thunderbird",
+			"cpe": "cpe:/o:redhat:enterprise_linux:6"
+		},
+		{
+			"product_name": "Red Hat Enterprise Linux 7",
+			"fix_state": "Not affected",
+			"package_name": "firefox",
+			"cpe": "cpe:/o:redhat:enterprise_linux:7"
+		},
+		{
+			"product_name": "Red Hat Enterprise Linux 7",
+			"fix_state": "Not affected",
+			"package_name": "thunderbird",
+			"cpe": "cpe:/o:redhat:enterprise_linux:7"
+		},
+		{
+			"product_name": "Red Hat Enterprise Linux 8",
+			"fix_state": "Not affected",
+			"package_name": "firefox",
+			"cpe": "cpe:/o:redhat:enterprise_linux:8"
+		},
+		{
+			"product_name": "Red Hat Enterprise Linux 8",
+			"fix_state": "Not affected",
+			"package_name": "thunderbird",
+			"cpe": "cpe:/o:redhat:enterprise_linux:8"
+		}
+	]
+}
+`
+
+func TestPackageFeed(t *testing.T) {
+	for i, test := range []struct {
+		feed     *Feed
+		expected summary
+	}{
+		{
+			testFeed(t, CVEMultiplePackages),
+			summary{
+				"qemu-kvm-ma":   []string{"CVE-2020-7211"},
+				"qemu-kvm":      []string{"CVE-2020-7211"},
+				"qemu-kvm-rhev": []string{"CVE-2020-7211"},
+				"slirp4netns":   []string{"CVE-2020-7211"},
+			},
+		},
+		{
+			testFeed(t, CVENoPackageState),
+			summary{
+				"chromium-browser": []string{"CVE-2020-6377"},
+			},
+		},
+		{
+			testFeed(t, CVEAffectedReleaseAndPackageState),
+			summary{
+				"nss-softokn": []string{"CVE-2019-11745"},
+				"nss":         []string{"CVE-2019-11745"},
+				"thunderbird": []string{"CVE-2019-11745"},
+				"firefox":     []string{"CVE-2019-11745"},
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+			pkgFeed := test.feed.packageFeed()
+			assert.Equal(t, test.expected, feedSummary(pkgFeed))
+		})
+	}
+
+}

--- a/providers/redhat/schema/schema.go
+++ b/providers/redhat/schema/schema.go
@@ -54,7 +54,7 @@ type CVE struct {
 	Mitigation      string   `json:"mitigation,omitempty"`
 	UpstreamFix     string   `json:"upstream_fix,omitempty"`
 
-	// redhat uses a single object insted of an array when there's a single instance of that entity
+	// redhat uses a single object instead of an array when there's a single instance of that entity
 	// that's why we need to do it manually
 	// the types of these are just helper types
 

--- a/rpm/checker.go
+++ b/rpm/checker.go
@@ -78,7 +78,7 @@ func Check(chk Checker, pkg, distro, cve string) (bool, error) {
 	return chk.Check(p, d, cve), nil
 }
 
-// FilterPackages will return those packages which haven't been fixed already on the given distro and for a given cve
+// FilterFixedPackages will return those packages which haven't been fixed already on the given distro and for a given cve
 // if some package can't be parsed as an rpm package, it will not be checked and will be included in the output list
 func FilterFixedPackages(chk Checker, pkgs []string, distro, cve string) ([]string, error) {
 	d, err := wfn.Parse(distro)

--- a/rpm/compare.go
+++ b/rpm/compare.go
@@ -35,17 +35,17 @@ func LabelCompare(l1, l2 Label) int {
 	// them is empty/not present, compare them using rpmvercmp() and follow the same
 	// logic; if one is “greater” (newer) than the other, that’s the end result of
 	// the comparison. Otherwise, move on to the next component (version).
-	if c := VersionCompare(l1.Epoch, l2.Epoch); c != 0 {
+	if c := versionCompare(l1.Epoch, l2.Epoch); c != 0 {
 		return c
 	}
 
 	// 3. Compare the versions using the same logic.
-	if c := VersionCompare(l1.Version, l2.Version); c != 0 {
+	if c := versionCompare(l1.Version, l2.Version); c != 0 {
 		return c
 	}
 
 	// 4. Compare the releases using the same logic.
-	if c := VersionCompare(l1.Release, l2.Release); c != 0 {
+	if c := versionCompare(l1.Release, l2.Release); c != 0 {
 		return c
 	}
 
@@ -53,7 +53,7 @@ func LabelCompare(l1, l2 Label) int {
 	return 0
 }
 
-func VersionCompare(v1, v2 string) int {
+func versionCompare(v1, v2 string) int {
 	// 1. If the strings are binary equal (a == b), they’re equal, return 0.
 	if v1 == v2 {
 		return 0

--- a/rpm/compare.go
+++ b/rpm/compare.go
@@ -19,6 +19,8 @@ import (
 	"unicode"
 )
 
+// LabelCompare returns 0 if the two packages have the same label, -1 if l1 < l2
+// and 1 of l1 > l2.
 func LabelCompare(l1, l2 Label) int {
 	// 1. Set each epoch value to 0 if it’s null/None.
 	if l1.Epoch == "" {

--- a/rpm/compare_test.go
+++ b/rpm/compare_test.go
@@ -39,7 +39,7 @@ func TestVersionCompare(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case-%d", i+1), func(t *testing.T) {
-			if r := VersionCompare(c.v1, c.v2); r != c.result {
+			if r := versionCompare(c.v1, c.v2); r != c.result {
 				t.Errorf("compare(%q, %q) = %d, expecting %d", c.v1, c.v2, r, c.result)
 			}
 		})
@@ -48,6 +48,6 @@ func TestVersionCompare(t *testing.T) {
 
 func BenchmarkVersionCompare(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		VersionCompare("1a2b3c4d", "1a2b3c4de")
+		versionCompare("1a2b3c4d", "1a2b3c4de")
 	}
 }

--- a/rpm/parse.go
+++ b/rpm/parse.go
@@ -33,7 +33,7 @@ type Label struct {
 	Release string
 }
 
-// FieldsFromRPMName returns name, version, release and architecture parsed from RPM package name
+// Parse returns name, version, release and architecture parsed from RPM package name
 // NEVRA: https://blog.jasonantman.com/2014/07/how-yum-and-rpm-compare-versions/
 func Parse(pkg string) (*Package, error) {
 	// pkg should be name-[epoch:]version-release.arch.rpm

--- a/rpm/rpm2wfn.go
+++ b/rpm/rpm2wfn.go
@@ -20,7 +20,7 @@ import (
 	"github.com/facebookincubator/nvdtools/wfn"
 )
 
-// FromRPMName parses CPE name from RPM package name
+// ToWFN parses CPE name from RPM package name
 func ToWFN(attr *wfn.Attributes, s string) error {
 	pkg, err := Parse(s)
 	if err != nil {


### PR DESCRIPTION
We'd like to annotate packages queried through `rpm -qa` or `dnf repoquery` with the list CVEs that aren't applicable to that package, either because the version packaged isn't impacted or because a fix has been pack ported.

We re-use the `rpm.Checker` interface already in place but with a twist.
- The `rpm.Checker` interface answers the question: "for the combination (distro, package, cve), is the CVE fixed?"
- What we want is "for each (distro, package) tuple, give me the list of non applicable/fixed CVEs.

To answer that question we start by turning the feed of CVEs retrieved fro RedHat inside out: we want a map that for each package name gives us the list of CVEs that potentially affect the package. We then use the `rpm.Checker` interface on each (distro, package, cve).

I've also included a tool to query this information and manually smoke test the results seem to make sense.

For instance, I've queried the list of fixed CVEs in the firefox 68.1.0 and 68.2.0 packages:

```
$  redhat2nvd -download  -since 240h > redhat-feed.json
$ go run ./cmd/redhat_query fixed-cves firefox-68.1.0-0.el6_10 firefox-68.2.0-4.el6_10
firefox-68.1.0-0.el6_10: CVE-2019-17015,CVE-2019-13722,CVE-2019-11745,CVE-2019-17009,CVE-2019-17021,CVE-2019-17013
firefox-68.2.0-4.el6_10: CVE-2019-11761,CVE-2019-17015,CVE-2019-11757,CVE-2019-11758,CVE-2019-17013,CVE-2019-11763,CVE-2019-11764,CVE-2019-11759,CVE-2019-17009,CVE-2019-13722,CVE-2019-17021,CVE-2019-11760,CVE-2019-11762,CVE-2019-11745
```