### PR TITLE
[redhat] Make ListFixedCVEs a lot faster when used with many packages

### DIFF
--- a/cmd/redhat_query/fixed-cves.go
+++ b/cmd/redhat_query/fixed-cves.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 
 	"github.com/facebookincubator/nvdtools/providers/redhat"
+	"github.com/facebookincubator/nvdtools/rpm"
+	"github.com/facebookincubator/nvdtools/wfn"
 	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
@@ -44,8 +46,18 @@ func fixedCVEs(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "fixed-cves")
 	}
 
+	distro, err := wfn.Parse(options.distro)
+	if err != nil {
+		return fmt.Errorf("fixed-cves: can't parse distro cpe %q: %v", distro, err)
+	}
+
 	for _, pkg := range args {
-		cves, err := feed.ListFixedCVEs(options.distro, pkg)
+		rpmPkg, err := rpm.Parse(pkg)
+		if err != nil {
+			return fmt.Errorf("fixed-cves: can't parse package %q: %v", pkg, err)
+		}
+
+		cves, err := feed.ListFixedCVEs(distro, rpmPkg)
 		if err != nil {
 			return errors.Wrap(err, "fixed-cves")
 		}

--- a/providers/redhat/feed.go
+++ b/providers/redhat/feed.go
@@ -32,6 +32,8 @@ type Feed struct {
 	data map[string]*schema.CVE
 	// pkgCVE is a package -> CVE map produced from data and cached.
 	pkg2CVE packageFeed
+	// rpm.Checker for this feed, cached.
+	checker rpm.Checker
 }
 
 // LoadFeed loads a Feed from a JSON file.
@@ -53,7 +55,10 @@ func loadFeed(r io.Reader) (*Feed, error) {
 }
 
 // Checker returns an rpm.Checker that uses the Feed.
-func (feed Feed) Checker() (rpm.Checker, error) {
+func (feed *Feed) Checker() (rpm.Checker, error) {
+	if feed.checker != nil {
+		return feed.checker, nil
+	}
 	mc := make(mapChecker, len(feed.data))
 	var err error
 	for cveid, cve := range feed.data {
@@ -66,6 +71,7 @@ func (feed Feed) Checker() (rpm.Checker, error) {
 			return nil, fmt.Errorf("can't create a checker for %q: %v", cveid, err)
 		}
 	}
+	feed.checker = mc
 	return mc, nil
 }
 

--- a/providers/redhat/package_feed.go
+++ b/providers/redhat/package_feed.go
@@ -15,7 +15,6 @@
 package redhat
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/facebookincubator/nvdtools/providers/redhat/schema"
@@ -91,16 +90,7 @@ func (feed *Feed) packageFeed() packageFeed {
 // been backported.
 // distro is a CPE identifying a distribution.
 // pkg is the full package name as reported, for instance by rpm -qa.
-func (feed *Feed) ListFixedCVEs(distro, pkg string) ([]string, error) {
-	d, err := wfn.Parse(distro)
-	if err != nil {
-		return nil, fmt.Errorf("list: can't parse distro cpe %q: %v", distro, err)
-	}
-	p, err := rpm.Parse(pkg)
-	if err != nil {
-		return nil, fmt.Errorf("list: can't parse package name %q: %v", pkg, err)
-	}
-
+func (feed *Feed) ListFixedCVEs(d *wfn.Attributes, p *rpm.Package) ([]string, error) {
 	pkgFeed := feed.packageFeed()
 	checker, err := feed.Checker()
 	if err != nil {


### PR DESCRIPTION
Turns out I overlooked that we were iterating through the whole Feed to produce
the rpm.Checker. We can cache it.

This makes calling ListFixedCVEs for ~50,000 packages go from 2 minutes to < 1s.

We also don't need to parse the distro string everytime.