### PR TITLE
[redhat] Sort the list of fixed CVEs

### DIFF
--- a/providers/redhat/package_feed.go
+++ b/providers/redhat/package_feed.go
@@ -16,6 +16,7 @@ package redhat
 
 import (
 	"log"
+	"sort"
 
 	"github.com/facebookincubator/nvdtools/providers/redhat/schema"
 	"github.com/facebookincubator/nvdtools/rpm"
@@ -103,6 +104,9 @@ func (feed *Feed) ListFixedCVEs(d *wfn.Attributes, p *rpm.Package) ([]string, er
 			cves = append(cves, cve.Name)
 		}
 	}
+
+	// Sort for deterministic output.
+	sort.Strings(cves)
 
 	return cves, nil
 }


### PR DESCRIPTION
I like to have a stable output between two invocations of tools for easier
comparison later on. The code producing the list of fixed CVEs loops though a
map, which isn't deterministic in go.

Sorting that list before handing it back to the user helps with that!