### PR TITLE
Optimize wfn.HasWildcard a bit.

### DIFF
--- a/wfn/matching.go
+++ b/wfn/matching.go
@@ -28,19 +28,20 @@ const (
 
 // HasWildcard returns true if attribute has a wildcard symbol in it
 func HasWildcard(s string) bool {
-	escaped := false
-	for _, r := range s {
-		if r == rune('\\') {
-			escaped = !escaped
+	for n, r := range s {
+		if r != '*' && r != '?' {
 			continue
 		}
-		if !escaped {
-			if r == rune('*') || r == rune('?') {
-				return true
+		quoted := false
+		for i := n - 1; i >= 0; i-- {
+			if s[i] != '\\' {
+				break
 			}
-			continue
+			quoted = !quoted
 		}
-		escaped = false
+		if !quoted {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
    During my recent profiling of real-world data, I've noticed, that
    cpe2cve tool spends about 37% of its time in wfn.HasWildcard.
    At this volume any win matters, so I've optimised it a little bit.
    Benchmarsk with Old suffix are for the old code, those without it
    were ran against the new code.
    
    ```
    $ go test -bench HasWildcard
    goos: linux
    goarch: amd64
    pkg: github.com/facebookincubator/nvdtools/wfn
    BenchmarkHasWildcard/has-4              74283427   16.2 ns/op
    BenchmarkHasWildcard/has_not-4          32665263   32.0 ns/op
    BenchmarkHasWildcard/has_escaped-4      45591032   26.2 ns/op
    BenchmarkHasWildcardOld/has-4           66978981   17.5 ns/op
    BenchmarkHasWildcardOld/has_not-4       30594387   38.2 ns/op
    BenchmarkHasWildcardOld/has_escaped-4   36729177   27.6 ns/op
    PASS
    ok      github.com/facebookincubator/nvdtools/wfn       8.901s
    ```
