### PR TITLE
Fix a bug in cpeMatch.match()

### DIFF
--- a/cvefeed/matching_json_test.go
+++ b/cvefeed/matching_json_test.go
@@ -43,6 +43,11 @@ func TestMatchJSON(t *testing.T) {
 			Inventory: []*wfn.Attributes{},
 		},
 		{
+			Rule:      0,
+			Inventory: []*wfn.Attributes{{}},
+			Matches:   []*wfn.Attributes{{}},
+		},
+		{
 			Inventory: []*wfn.Attributes{
 				{Part: "o", Vendor: "linux", Product: "linux_kernel", Version: "2\\.6\\.1"},
 				{Part: "a", Vendor: "djvulibre_project", Product: "djvulibre", Version: "3\\.5\\.11"},
@@ -61,6 +66,11 @@ func TestMatchJSON(t *testing.T) {
 			},
 		},
 		{
+			Rule:      1,
+			Inventory: []*wfn.Attributes{{}},
+			Matches:   []*wfn.Attributes{{}},
+		},
+		{
 			Rule: 1,
 			Inventory: []*wfn.Attributes{
 				{Part: "a", Vendor: "microsoft", Product: "ie", Version: "3\\.9"},
@@ -72,6 +82,11 @@ func TestMatchJSON(t *testing.T) {
 				{Part: "a", Vendor: "microsoft", Product: "ie", Version: "4\\.0"},
 				{Part: "a", Vendor: "microsoft", Product: "ie", Version: "5\\.4"},
 			},
+		},
+		{
+			Rule:      2,
+			Inventory: []*wfn.Attributes{{}},
+			Matches:   []*wfn.Attributes{{}},
 		},
 		{
 			Rule: 2,

--- a/cvefeed/nvd/match_cpe.go
+++ b/cvefeed/nvd/match_cpe.go
@@ -106,6 +106,10 @@ func (cm *cpeMatch) match(attr *wfn.Attributes, requireVersion bool) bool {
 	//	- matched attr without version
 	//  - didn't match version, or require version was set and version was *
 
+	if attr.Version == wfn.Any {
+		return true
+	}
+
 	if !cm.hasVersionRanges {
 		return false
 	}

--- a/wfn/matcher.go
+++ b/wfn/matcher.go
@@ -84,11 +84,9 @@ func (mm *multiMatcher) Match(attrs []*Attributes, requireVersion bool) []*Attri
 		}
 	}
 
-	matches := make([]*Attributes, len(matched))
-	i := 0
+	matches := make([]*Attributes, 0, len(matched))
 	for m := range matched {
-		matches[i] = m
-		i++
+		matches = append(matches, m)
 	}
 	return matches
 }


### PR DESCRIPTION
The matching logic did not account for version=ANY in wfn.Attributes
received as an argument.

I added some cases to TestMatchJSON() to reproduce, rule#1 was failing
before the fix.