### PR TITLE
[redhat_query] Add a command to fetch a single CVE from RedHat

### DIFF
--- a/cmd/redhat_query/fetch-cve.go
+++ b/cmd/redhat_query/fetch-cve.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/facebookincubator/nvdtools/providers/lib/client"
+	"github.com/facebookincubator/nvdtools/providers/redhat/api"
+)
+
+var fetchCVECmd = &cobra.Command{
+	Use:   "fetch-cve CVE-XXXX-YYYY",
+	Short: "fetch the latest information about a CVE",
+	RunE:  fetchCVE,
+}
+
+func init() {
+	rootCmd.AddCommand(fetchCVECmd)
+}
+
+func fetchCVE(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return errors.New("fetch-cve: missing CVE name")
+	}
+	cveID := args[0]
+
+	httpClient := client.Default()
+	config := client.Config{
+		UserAgent: "redhat_query",
+	}
+	httpClient = config.Configure(httpClient)
+
+	feed := api.NewClient(httpClient, "https://access.redhat.com/labs/securitydataapi")
+	cve, err := feed.FetchCVE(context.Background(), cveID)
+	if err != nil {
+		return err
+	}
+
+	output, err := json.MarshalIndent(cve, "", " ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(output))
+
+	return nil
+}

--- a/providers/redhat/api/client.go
+++ b/providers/redhat/api/client.go
@@ -48,7 +48,7 @@ func NewClient(c client.Client, baseURL string) *Client {
 	}
 }
 
-// FetchAll will fetch all vulnerabilities
+// FetchAllCVEs will fetch all vulnerabilities
 func (c *Client) FetchAllCVEs(ctx context.Context, since int64) (<-chan runner.Convertible, error) {
 	output := make(chan runner.Convertible)
 	wg := sync.WaitGroup{}
@@ -59,7 +59,7 @@ func (c *Client) FetchAllCVEs(ctx context.Context, since int64) (<-chan runner.C
 			go func(cveid string) {
 				defer wg.Done()
 				log.Printf("\tfetching cve %s", cveid)
-				cve, err := c.fetchCVE(ctx, cveid)
+				cve, err := c.FetchCVE(ctx, cveid)
 				if err != nil {
 					log.Printf("error while fetching cve %s: %v", cveid, err)
 					return
@@ -77,7 +77,8 @@ func (c *Client) FetchAllCVEs(ctx context.Context, since int64) (<-chan runner.C
 	return output, nil
 }
 
-func (c *Client) fetchCVE(ctx context.Context, cveid string) (*schema.CVE, error) {
+// FetchCVE retrieves a single CVE.
+func (c *Client) FetchCVE(ctx context.Context, cveid string) (*schema.CVE, error) {
 	resp, err := c.queryPath(ctx, fmt.Sprintf("/cve/%s.json", cveid))
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch from feed: %v", err)


### PR DESCRIPTION
I needed to check if CVE information hadn't been updated for a particular CVE.
This little utility does just that.

```
$ redhat_query fetch-cve CVE-2013-1961
{
 "name": "CVE-2013-1961",
 "threat_severity": "Low",
 "public_date": "2013-05-02T00:00:00Z",
 "bugzilla": {
  "description": "CVE-2013-1961 libtiff (tiff2pdf): Stack-based buffer overflow with malformed image-length and resolution",
  "id": "952131",
  "url": "https://bugzilla.redhat.com/show_bug.cgi?id=952131"
 },
 "CVSS": {
  "cvss_base_score": "4.3",
  "cvss_scoring_vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
  "status": "verified"
 },
 "cwe": "CWE-121",
 "details": [
  "Stack-based buffer overflow in the t2p_write_pdf_page function in tiff2pdf in libtiff before 4.0.3 allows remote attackers to cause a denial of service (application crash) via a crafted image length and resolution in a TIFF image file."
 ],
 "acknowledgement": "Red Hat would like to thank Emmanuel Bouillon (NCI Agency) for reporting this issue.",
 "affected_release": [
  {
   "product_name": "Red Hat Enterprise Linux 5",
   "release_date": "2014-02-27T00:00:00Z",
   "advisory": "RHSA-2014:0223",
   "package": "libtiff-0:3.8.2-19.el5_10",
   "cpe": "cpe:/o:redhat:enterprise_linux:5"
  },
  {
   "product_name": "Red Hat Enterprise Linux 6",
   "release_date": "2014-02-27T00:00:00Z",
   "advisory": "RHSA-2014:0222",
   "package": "libtiff-0:3.9.4-10.el6_5",
   "cpe": "cpe:/o:redhat:enterprise_linux:6"
  }
 ]
}
```