### PR TITLE
[redhat] Fix unmarshalling of the mitigation field

### DIFF
--- a/providers/redhat/schema/schema.go
+++ b/providers/redhat/schema/schema.go
@@ -51,8 +51,11 @@ type CVE struct {
 	Statement       string   `json:"statement,omitempty"`
 	References      []string `json:"references,omitempty"`
 	Acknowledgement string   `json:"acknowledgement,omitempty"`
-	Mitigation      string   `json:"mitigation,omitempty"`
-	UpstreamFix     string   `json:"upstream_fix,omitempty"`
+	Mitigation      *struct {
+		Value string `json:"value"`
+		Lang  string `json:"lang"`
+	} `json:"mitigation,omitempty"`
+	UpstreamFix string `json:"upstream_fix,omitempty"`
 
 	// redhat uses a single object instead of an array when there's a single instance of that entity
 	// that's why we need to do it manually


### PR DESCRIPTION
Turns out we were never unmarshalling data with a mitigation field because it's
not a string but an object with a couple of fields:

```
[...]
  "mitigation": {
    "value": "This flaw is in the memcached binary protocol. If your client programs only use the ASCII protocol when communicating with memcached, you can disable the binary protocol and protect against this flaw by adding \"-B ascii\" to OPTIONS in /etc/sysconfig/memcached.",
    "lang": "en:us"
  }
[...]
```

This means we were skipping all CVE entries with a mitigation field in redhat2nvd 😱!

I looked at historical data and that field isn't present in the CVEs with do
have so it was probably never a string!

Before:

```
$ redhat_query fetch-cve CVE-2016-8705
failed to decode cve response into a cve: json: cannot unmarshal object into Go struct field CVE.mitigation of type string
```

After:

```
$ redhat_query fetch-cve CVE-2016-8705 | jq .
{
  "name": "CVE-2016-8705",
  "threat_severity": "Important",
  "public_date": "2016-10-31T00:00:00Z",
  "bugzilla": {
    "description": "CVE-2016-8705 memcached: Server update remote code execution",
    "id": "1390511",
    "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1390511"
  },
[...]
```