### PR TITLE
How about add nvdtools cpe2cve as a http api?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 
 script:
 - go get -v -t -u -d ./...
-- 'golangci-lint run ./... --disable-all -E gosimple -E govet -E ineffassign -E staticcheck -E structcheck -E varcheck -e SA5011:'
+- 'golangci-lint run ./... --disable-all -E golint -E gosimple -E govet -E ineffassign -E staticcheck -E structcheck -E varcheck -e SA5011:'
 - go test -v ./...
 
 before_deploy:

--- a/cmd/cpe2cve/config.go
+++ b/cmd/cpe2cve/config.go
@@ -59,6 +59,8 @@ type config struct {
 	// feeds
 	FeedOverrides multiString // []string
 	Feeds         map[string][]string
+	// http uri
+	HttpBindAt string
 }
 
 func (cfg *config) addFlags() {
@@ -93,6 +95,9 @@ func (cfg *config) addFlags() {
 
 	// feeds
 	flag.Var(&cfg.FeedOverrides, "r", "overRide: path to override feed, can be specified multiple times")
+
+	// feeds
+	flag.StringVar(&cfg.HttpBindAt, "bind", "", "use http based api. endp: [server:port]/cpe/your_cpe_name")
 }
 
 func (cfg *config) addFeedsFromArgs(provider string, feedFiles ...string) {

--- a/cmd/vulndb/diffcmd.go
+++ b/cmd/vulndb/diffcmd.go
@@ -1,0 +1,121 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"path/filepath"
+	"sort"
+
+	"github.com/facebookincubator/nvdtools/cvefeed"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(diffCmd)
+}
+
+func feedLoad(file string) (cvefeed.Dictionary, error) {
+	log.Printf("loading %s\n", file)
+	dict, err := cvefeed.LoadJSONDictionary(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load dictionary %s: %v", file, err)
+	}
+	return dict, nil
+}
+
+func feedName(file string) string {
+	return filepath.Base(file[:len(file)-5])
+}
+
+func printArraySorted(a []string, indent string, n int) {
+	min := func(a, b int) int {
+		if a <= b {
+			return a
+		}
+		return b
+	}
+
+	sort.Strings(a)
+	for i := 0; i < min(len(a), n); i++ {
+		fmt.Printf("%s%s\n", indent, a[i])
+	}
+	if len(a) > n {
+		fmt.Printf("%s... (%d more)\n", indent, len(a)-10)
+	}
+}
+
+var diffCmd = &cobra.Command{
+	Use:   "diff [flags] a.json b.json",
+	Short: "diff two vulnerability feeds",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		percentInt := func(a, b int) float64 {
+			return float64(a) / float64(b) * 100
+		}
+
+		if len(args) != 2 {
+			return errors.New("missing JSON export files")
+		}
+
+		aDict, err := feedLoad(args[0])
+		if err != nil {
+			return err
+		}
+
+		bDict, err := feedLoad(args[1])
+
+		if err != nil {
+			return err
+		}
+
+		log.Println("computing stats")
+
+		a := feedName(args[0])
+		b := feedName(args[1])
+
+		stats := cvefeed.Diff(a, aDict, b, bDict)
+
+		fmt.Printf("Num vulnerabilities in %s: %d\n", a, stats.NumVulnsA())
+		fmt.Printf("Num vulnerabilities in %s: %d\n", b, stats.NumVulnsB())
+		fmt.Printf("Num vulnerabilities in %s but not in %s: %d\n", a, b, stats.NumVulnsANotB())
+		printArraySorted(stats.VulnsANotB(), "    ", 10)
+		fmt.Printf("Num vulnerabilities in %s but not in %s: %d\n", b, a, stats.NumVulnsBNotA())
+		printArraySorted(stats.VulnsBNotA(), "    ", 10)
+		fmt.Println()
+		fmt.Printf("Different vulnerabilities: %d\n", stats.NumDiffVulns())
+		fmt.Printf("    different descriptions: %d (%.2f%%, total %.2f%%)\n",
+			stats.NumChunk(cvefeed.ChunkDescription), stats.PercentChunk(cvefeed.ChunkDescription),
+			percentInt(stats.NumChunk(cvefeed.ChunkDescription), stats.NumVulnsA()))
+		fmt.Printf("    different scores      : %d (%.2f%%, total %.2f%%)\n",
+			stats.NumChunk(cvefeed.ChunkScore), stats.PercentChunk(cvefeed.ChunkScore),
+			percentInt(stats.NumChunk(cvefeed.ChunkScore), stats.NumVulnsA()))
+
+		log.Println("writing differences to stats.json")
+
+		data, err := json.MarshalIndent(stats, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to encode stats to JSON: %w", err)
+		}
+		if err := ioutil.WriteFile("stats.json", data, 0644); err != nil {
+			return fmt.Errorf("failed to write stats file: %w", err)
+		}
+
+		return nil
+	},
+}

--- a/cmd/vulndb/exportcmd.go
+++ b/cmd/vulndb/exportcmd.go
@@ -38,7 +38,7 @@ var exportCmd = &cobra.Command{
 	Long: `
 The export command returns data from all vendors + overrides.
 
-The --format flag is required and must be one of csv or nvdjson.
+The --format flag is required and must be one of csv or nvdcvejson.
 
 The --provider flag is optional, as well as the list of IDs to filter in.
 

--- a/cmd/vulndb/schema.go
+++ b/cmd/vulndb/schema.go
@@ -28,7 +28,7 @@ func init() {
 
 var schemaCmd = &cobra.Command{
 	Use:   "schema",
-	Short: "dump vulndb MySQL schema to standatd output",
+	Short: "dump vulndb MySQL schema to standard output",
 	Run: func(cmd *cobra.Command, args []string) {
 		for _, part := range vulndb.SchemaSQL() {
 			fmt.Println(part)

--- a/cvefeed/dictionary.go
+++ b/cvefeed/dictionary.go
@@ -41,7 +41,7 @@ func (d *Dictionary) Override(d2 Dictionary) {
 	}
 }
 
-// LoadJSONDictionary parses dictionary from multiple NVD vulenrability feed JSON files
+// LoadJSONDictionary parses dictionary from multiple NVD vulnerability feed JSON files
 func LoadJSONDictionary(paths ...string) (Dictionary, error) {
 	return LoadFeed(loadJSONFile, paths...)
 }

--- a/cvefeed/diff.go
+++ b/cvefeed/diff.go
@@ -1,0 +1,293 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cvefeed
+
+import (
+	"encoding/json"
+	"math/bits"
+
+	"github.com/facebookincubator/nvdtools/cvefeed/nvd"
+	"github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
+)
+
+type bag map[string]interface{}
+
+// ChunkKind is the type of chunks produced by a diff.
+type ChunkKind string
+
+const (
+	// ChunkDescription indicates a difference in the description of a
+	// vulnerability.
+	ChunkDescription ChunkKind = "description"
+	// ChunkScore indicates a difference in the score of a vulnerability.
+	ChunkScore = "score"
+)
+
+type chunk uint32
+
+const (
+	chunkDescriptionShift = iota
+	chunkScoreShift
+	chunkMaxShift
+)
+
+const (
+	chunkDescription chunk = 1 << iota
+	chunkScore
+)
+
+var chunkKind = [chunkMaxShift]ChunkKind{
+	ChunkDescription,
+	ChunkScore,
+}
+
+func (kind ChunkKind) shift() int {
+	for i, v := range chunkKind {
+		if v == kind {
+			return i
+		}
+	}
+	return chunkMaxShift
+}
+
+type diffEntry struct {
+	id   string
+	bits chunk
+}
+
+type diffFeed struct {
+	name string
+	dict Dictionary
+}
+
+type diff struct {
+	a, b diffFeed
+}
+
+func newDiff(a, b diffFeed) *diff {
+	return &diff{
+		a: a,
+		b: b,
+	}
+}
+
+// DiffStats is the result of a diff.
+type DiffStats struct {
+	diff *diff // back pointer to the diff these stats are for
+
+	numVulnsA, numVulnsB int
+
+	aNotB     []string // ids of vulns that are in a but not in b
+	bNotA     []string // ids of vulns that are in b but not in a
+	entries   []diffEntry
+	bitCounts [chunkMaxShift]int
+}
+
+// NumVulnsA returns the vulnerability in A (the first input to Diff).
+func (s *DiffStats) NumVulnsA() int {
+	return s.numVulnsA
+}
+
+// NumVulnsB returns the vulnerability in A (the first input to Diff).
+func (s *DiffStats) NumVulnsB() int {
+	return s.numVulnsB
+}
+
+// VulnsANotB returns the vulnerabilities that are A (the first input to Diff) but
+// are not in B (the second input to Diff).
+func (s *DiffStats) VulnsANotB() []string {
+	return s.aNotB
+}
+
+// NumVulnsANotB returns the numbers of vulnerabilities that are A (the first input
+// to Diff) but are not in B (the second input to Diff).
+func (s *DiffStats) NumVulnsANotB() int {
+	return len(s.aNotB)
+}
+
+// VulnsBNotA returns the vulnerabilities that are A (the first input to Diff) but
+// are not in B (the second input to Diff).
+func (s *DiffStats) VulnsBNotA() []string {
+	return s.bNotA
+}
+
+// NumVulnsBNotA returns the numbers of vulnerabilities that are B (the second input
+// to Diff) but are not in A (the first input to Diff).
+func (s *DiffStats) NumVulnsBNotA() int {
+	return len(s.bNotA)
+}
+
+// NumDiffVulns returns the number of vulnerability that are in both A and B but
+// are different (eg. different description, score, ...).
+func (s *DiffStats) NumDiffVulns() int {
+	return len(s.entries)
+}
+
+// NumChunk returns the number of different vulnerabilities that have a specific chunk.
+func (s *DiffStats) NumChunk(chunk ChunkKind) int {
+	return s.bitCounts[chunk.shift()]
+}
+
+// PercentChunk returns the percentage of different vulnerabilities that have a specific chunk.
+func (s *DiffStats) PercentChunk(chunk ChunkKind) float64 {
+	return float64(s.bitCounts[chunk.shift()]) / float64(len(s.entries)) * 100
+}
+
+func diffDetails(s *schema.NVDCVEFeedJSON10DefCVEItem, bit chunk) bag {
+	var v interface{}
+
+	switch bit {
+	case chunkDescription:
+		v = bag{
+			"description": englishDescription(s),
+		}
+	case chunkScore:
+		v = s.Impact
+	}
+
+	var data bag
+	tmp, _ := json.Marshal(v)
+	_ = json.Unmarshal(tmp, &data)
+
+	return data
+}
+
+func genEntryDiffOutput(aFeed, bFeed *diffFeed, entry *diffEntry) []bag {
+	a := aFeed.dict[entry.id].(*nvd.Vuln).Schema()
+	b := bFeed.dict[entry.id].(*nvd.Vuln).Schema()
+	outputs := make([]bag, bits.OnesCount32(uint32(entry.bits)))
+	for i := 0; i < chunkMaxShift; i++ {
+		if entry.bits&(1<<i) != 0 {
+			outputs[i] = bag{
+				"kind":     chunkKind[i],
+				aFeed.name: diffDetails(a, 1<<i),
+				bFeed.name: diffDetails(b, 1<<i),
+			}
+		}
+	}
+	return outputs
+}
+
+// MarshalJSON implements a custom JSON marshaller.
+func (s *DiffStats) MarshalJSON() ([]byte, error) {
+	var differences []bag
+	for _, entry := range s.entries {
+		differences = append(differences, bag{
+			"id":     entry.id,
+			"chunks": genEntryDiffOutput(&s.diff.a, &s.diff.b, &entry),
+		})
+	}
+	return json.Marshal(bag{
+		"differences": differences,
+	})
+}
+
+func englishDescription(s *schema.NVDCVEFeedJSON10DefCVEItem) string {
+	for _, d := range s.CVE.Description.DescriptionData {
+		if d.Lang == "en" {
+			return d.Value
+		}
+	}
+	return ""
+}
+
+func sameDescription(a, b *schema.NVDCVEFeedJSON10DefCVEItem) bool {
+	return englishDescription(a) == englishDescription(b)
+}
+
+func sameScoreCVSSV2(a, b *schema.NVDCVEFeedJSON10DefCVEItem) bool {
+	var aScore, bScore float64
+	var aVector, bVector string
+
+	if a.Impact.BaseMetricV2 != nil && a.Impact.BaseMetricV2.CVSSV2 != nil {
+		aScore = a.Impact.BaseMetricV2.CVSSV2.BaseScore
+		aVector = a.Impact.BaseMetricV2.CVSSV2.VectorString
+	}
+	if b.Impact.BaseMetricV2 != nil && b.Impact.BaseMetricV2.CVSSV2 != nil {
+		bScore = b.Impact.BaseMetricV2.CVSSV2.BaseScore
+		bVector = b.Impact.BaseMetricV2.CVSSV2.VectorString
+	}
+	return aScore == bScore && aVector == bVector
+}
+
+func sameScoreCVSSV3(a, b *schema.NVDCVEFeedJSON10DefCVEItem) bool {
+	var aScore, bScore float64
+	var aVector, bVector string
+
+	if a.Impact.BaseMetricV3 != nil && a.Impact.BaseMetricV3.CVSSV3 != nil {
+		aScore = a.Impact.BaseMetricV3.CVSSV3.BaseScore
+		aVector = a.Impact.BaseMetricV3.CVSSV3.VectorString
+	}
+	if b.Impact.BaseMetricV3 != nil && b.Impact.BaseMetricV3.CVSSV3 != nil {
+		bScore = b.Impact.BaseMetricV3.CVSSV3.BaseScore
+		bVector = b.Impact.BaseMetricV3.CVSSV3.VectorString
+	}
+	return aScore == bScore && aVector == bVector
+}
+
+func sameScore(a, b *schema.NVDCVEFeedJSON10DefCVEItem) bool {
+	return sameScoreCVSSV2(a, b) && sameScoreCVSSV3(a, b)
+}
+
+func (d *diff) stats() *DiffStats {
+	stats := DiffStats{
+		diff:      d,
+		numVulnsA: len(d.a.dict),
+		numVulnsB: len(d.b.dict),
+	}
+
+	// List of vulns that are in a but not in b.
+	for key := range d.a.dict {
+		if _, ok := d.b.dict[key]; !ok {
+			stats.aNotB = append(stats.aNotB, key)
+			continue
+		}
+
+		// key is in both a and b, let's compare further!
+		a := d.a.dict[key].(*nvd.Vuln).Schema()
+		b := d.b.dict[key].(*nvd.Vuln).Schema()
+
+		var entry diffEntry
+
+		if !sameDescription(a, b) {
+			entry.bits |= chunkDescription
+			stats.bitCounts[chunkDescriptionShift]++
+		}
+		if !sameScore(a, b) {
+			entry.bits |= chunkScore
+			stats.bitCounts[chunkScoreShift]++
+		}
+
+		if entry.bits != 0 {
+			entry.id = key
+			stats.entries = append(stats.entries, entry)
+		}
+	}
+
+	// List of vulns that are in b but not in a.
+	for key := range d.b.dict {
+		if _, ok := d.a.dict[key]; !ok {
+			stats.bNotA = append(stats.bNotA, key)
+		}
+	}
+
+	return &stats
+}
+
+// Diff performs a diff between two Dictionaries.
+func Diff(aName string, aDict Dictionary, bName string, bDict Dictionary) *DiffStats {
+	diff := newDiff(diffFeed{aName, aDict}, diffFeed{bName, bDict})
+	return diff.stats()
+}

--- a/cvefeed/feed.go
+++ b/cvefeed/feed.go
@@ -20,6 +20,7 @@ package cvefeed
 
 import (
 	"bufio"
+	"compress/bzip2"
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
@@ -75,6 +76,9 @@ func setupReader(in io.Reader) (src io.ReadCloser, err error) {
 			return nil, err
 		}
 		src = zr
+	} else if header[0] == 'B' && header[1] == 'Z' {
+		// or with bzip2.Reader if bzip2'ed
+		src = ioutil.NopCloser(bzip2.NewReader(r))
 	}
 	// TODO: maybe support .zip
 	return src, nil

--- a/cvefeed/nvd/match_cve.go
+++ b/cvefeed/nvd/match_cve.go
@@ -45,6 +45,11 @@ type Vuln struct {
 	wfn.Matcher
 }
 
+// Schema returns the underlying schema of the Vuln
+func (v *Vuln) Schema() *schema.NVDCVEFeedJSON10DefCVEItem {
+	return v.cveItem
+}
+
 // ID is a part of the cvefeed.Vuln Interface
 func (v *Vuln) ID() string {
 	if v == nil || v.cveItem == nil || v.cveItem.CVE == nil || v.cveItem.CVE.CVEDataMeta == nil {

--- a/providers/idefense/api/client.go
+++ b/providers/idefense/api/client.go
@@ -33,7 +33,7 @@ import (
 // Client struct
 type Client struct {
 	client.Client
-	baseUrl string
+	baseURL string
 	apiKey  string
 }
 
@@ -43,10 +43,10 @@ const (
 )
 
 // NewClient creates an object which is used to query the iDefense API
-func NewClient(c client.Client, baseUrl, apiKey string) *Client {
+func NewClient(c client.Client, baseURL, apiKey string) *Client {
 	return &Client{
 		Client:  c,
-		baseUrl: baseUrl,
+		baseURL: baseURL,
 		apiKey:  apiKey,
 	}
 }
@@ -107,7 +107,7 @@ func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-ch
 }
 
 func (c *Client) queryVulnerabilities(ctx context.Context, params map[string]interface{}) (*schema.VulnerabilitySearchResults, error) {
-	u, err := url.Parse(c.baseUrl + vulnerabilityEndpoint)
+	u, err := url.Parse(c.baseURL + vulnerabilityEndpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse url")
 	}

--- a/providers/redhat/check/check_cve.go
+++ b/providers/redhat/check/check_cve.go
@@ -23,25 +23,26 @@ import (
 	"github.com/facebookincubator/nvdtools/wfn"
 )
 
-var NoCheckers = errors.New("no applicable checkers")
+var ErrCheckers = errors.New("no applicable checkers")
 
 func CVEChecker(cve *schema.CVE) (rpm.Checker, error) {
 	var chks []rpm.Checker
 
-	if archks, err := affectedReleaseCheckers(cve); err != nil {
+	archks, err := affectedReleaseCheckers(cve)
+	if err != nil {
 		return nil, fmt.Errorf("can't construct checkers for affected release: %v", err)
-	} else {
-		chks = archks
 	}
+	chks = archks
 
-	if pschks, err := packageStateCheckers(cve); err != nil {
+	pschks, err := packageStateCheckers(cve)
+	if err != nil {
 		return nil, fmt.Errorf("can't construct checkers for package state: %v", err)
-	} else {
-		chks = append(chks, pschks...)
 	}
+	chks = append(chks, pschks...)
+
 
 	if len(chks) == 0 {
-		return nil, NoCheckers
+		return nil, ErrCheckers
 	}
 
 	return &cveChecker{cve.Name, chks}, nil

--- a/providers/redhat/feed.go
+++ b/providers/redhat/feed.go
@@ -63,7 +63,7 @@ func (feed *Feed) Checker() (rpm.Checker, error) {
 	var err error
 	for cveid, cve := range feed.data {
 		if mc[cveid], err = check.CVEChecker(cve); err != nil {
-			if err == check.NoCheckers {
+			if err == check.ErrCheckers {
 				// no checkers could be created, just skip it
 				delete(mc, cveid)
 				continue

--- a/rpm/compare.go
+++ b/rpm/compare.go
@@ -114,9 +114,8 @@ func versionCompare(v1, v2 string) int {
 		if len(v2Seg) == 0 {
 			if isNumeric {
 				return 1
-			} else {
-				return -1
 			}
+			return -1
 		}
 
 		// here we know that they both start with either numbers or letters


### PR DESCRIPTION
Hi:
    This is a demo that let cpe2cve as a http api. a live demo is running at http://hk.fht.im:8080. 
```bash
curl -s "http://hk.fht.im:8080/cpe/cpe:2.3:a:gnu:bash:1.14.4:*:*:*:*:*:*:*" | jq
{
  "resp": [
    "CVE-2014-6277",
    "CVE-2014-6271",
    "CVE-2016-9401",
    "CVE-2014-7187",
    "CVE-1999-1383",
    "CVE-2016-7543",
    "CVE-2014-6278",
    "CVE-2014-7186",
    "CVE-2019-18276",
    "CVE-2014-7169",
    "CVE-2019-9924",
    "CVE-1999-0491"
  ]
}
```
     Cloud I merge in this feature? 