### PR TITLE
[vulndb] Fix the help text with the correct format parameter

### DIFF
--- a/cmd/vulndb/exportcmd.go
+++ b/cmd/vulndb/exportcmd.go
@@ -38,7 +38,7 @@ var exportCmd = &cobra.Command{
 	Long: `
 The export command returns data from all vendors + overrides.
 
-The --format flag is required and must be one of csv or nvdjson.
+The --format flag is required and must be one of csv or nvdcvejson.
 
 The --provider flag is optional, as well as the list of IDs to filter in.
 


### PR DESCRIPTION
--format nvdcvejson is the correct invocation, not nvdjson!