### PR TITLE
vulndb diff

### DIFF
--- a/cmd/vulndb/diffcmd.go
+++ b/cmd/vulndb/diffcmd.go
@@ -1,0 +1,121 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"path/filepath"
+	"sort"
+
+	"github.com/facebookincubator/nvdtools/cvefeed"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(diffCmd)
+}
+
+func feedLoad(file string) (cvefeed.Dictionary, error) {
+	log.Printf("loading %s\n", file)
+	dict, err := cvefeed.LoadJSONDictionary(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load dictionary %s: %v", file, err)
+	}
+	return dict, nil
+}
+
+func feedName(file string) string {
+	return filepath.Base(file[:len(file)-5])
+}
+
+func printArraySorted(a []string, indent string, n int) {
+	min := func(a, b int) int {
+		if a <= b {
+			return a
+		}
+		return b
+	}
+
+	sort.Strings(a)
+	for i := 0; i < min(len(a), n); i++ {
+		fmt.Printf("%s%s\n", indent, a[i])
+	}
+	if len(a) > n {
+		fmt.Printf("%s... (%d more)\n", indent, len(a)-10)
+	}
+}
+
+var diffCmd = &cobra.Command{
+	Use:   "diff [flags] a.json b.json",
+	Short: "diff two vulnerability feeds",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		percentInt := func(a, b int) float64 {
+			return float64(a) / float64(b) * 100
+		}
+
+		if len(args) != 2 {
+			return errors.New("missing JSON export files")
+		}
+
+		aDict, err := feedLoad(args[0])
+		if err != nil {
+			return err
+		}
+
+		bDict, err := feedLoad(args[1])
+
+		if err != nil {
+			return err
+		}
+
+		log.Println("computing stats")
+
+		a := feedName(args[0])
+		b := feedName(args[1])
+
+		stats := cvefeed.Diff(a, aDict, b, bDict)
+
+		fmt.Printf("Num vulnerabilities in %s: %d\n", a, stats.NumVulnsA())
+		fmt.Printf("Num vulnerabilities in %s: %d\n", b, stats.NumVulnsB())
+		fmt.Printf("Num vulnerabilities in %s but not in %s: %d\n", a, b, stats.NumVulnsANotB())
+		printArraySorted(stats.VulnsANotB(), "    ", 10)
+		fmt.Printf("Num vulnerabilities in %s but not in %s: %d\n", b, a, stats.NumVulnsBNotA())
+		printArraySorted(stats.VulnsBNotA(), "    ", 10)
+		fmt.Println()
+		fmt.Printf("Different vulnerabilities: %d\n", stats.NumDiffVulns())
+		fmt.Printf("    different descriptions: %d (%.2f%%, total %.2f%%)\n",
+			stats.NumChunk(cvefeed.ChunkDescription), stats.PercentChunk(cvefeed.ChunkDescription),
+			percentInt(stats.NumChunk(cvefeed.ChunkDescription), stats.NumVulnsA()))
+		fmt.Printf("    different scores      : %d (%.2f%%, total %.2f%%)\n",
+			stats.NumChunk(cvefeed.ChunkScore), stats.PercentChunk(cvefeed.ChunkScore),
+			percentInt(stats.NumChunk(cvefeed.ChunkScore), stats.NumVulnsA()))
+
+		log.Println("writing differences to stats.json")
+
+		data, err := json.MarshalIndent(stats, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to encode stats to JSON: %w", err)
+		}
+		if err := ioutil.WriteFile("stats.json", data, 0644); err != nil {
+			return fmt.Errorf("failed to write stats file: %w", err)
+		}
+
+		return nil
+	},
+}

--- a/cvefeed/dictionary.go
+++ b/cvefeed/dictionary.go
@@ -41,7 +41,7 @@ func (d *Dictionary) Override(d2 Dictionary) {
 	}
 }
 
-// LoadJSONDictionary parses dictionary from multiple NVD vulenrability feed JSON files
+// LoadJSONDictionary parses dictionary from multiple NVD vulnerability feed JSON files
 func LoadJSONDictionary(paths ...string) (Dictionary, error) {
 	return LoadFeed(loadJSONFile, paths...)
 }

--- a/cvefeed/diff.go
+++ b/cvefeed/diff.go
@@ -1,0 +1,293 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cvefeed
+
+import (
+	"encoding/json"
+	"math/bits"
+
+	"github.com/facebookincubator/nvdtools/cvefeed/nvd"
+	"github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
+)
+
+type bag map[string]interface{}
+
+// ChunkKind is the type of chunks produced by a diff.
+type ChunkKind string
+
+const (
+	// ChunkDescription indicates a difference in the description of a
+	// vulnerability.
+	ChunkDescription ChunkKind = "description"
+	// ChunkScore indicates a difference in the score of a vulnerability.
+	ChunkScore = "score"
+)
+
+type chunk uint32
+
+const (
+	chunkDescriptionShift = iota
+	chunkScoreShift
+	chunkMaxShift
+)
+
+const (
+	chunkDescription chunk = 1 << iota
+	chunkScore
+)
+
+var chunkKind = [chunkMaxShift]ChunkKind{
+	ChunkDescription,
+	ChunkScore,
+}
+
+func (kind ChunkKind) shift() int {
+	for i, v := range chunkKind {
+		if v == kind {
+			return i
+		}
+	}
+	return chunkMaxShift
+}
+
+type diffEntry struct {
+	id   string
+	bits chunk
+}
+
+type diffFeed struct {
+	name string
+	dict Dictionary
+}
+
+type diff struct {
+	a, b diffFeed
+}
+
+func newDiff(a, b diffFeed) *diff {
+	return &diff{
+		a: a,
+		b: b,
+	}
+}
+
+// DiffStats is the result of a diff.
+type DiffStats struct {
+	diff *diff // back pointer to the diff these stats are for
+
+	numVulnsA, numVulnsB int
+
+	aNotB     []string // ids of vulns that are in a but not in b
+	bNotA     []string // ids of vulns that are in b but not in a
+	entries   []diffEntry
+	bitCounts [chunkMaxShift]int
+}
+
+// NumVulnsA returns the vulnerability in A (the first input to Diff).
+func (s *DiffStats) NumVulnsA() int {
+	return s.numVulnsA
+}
+
+// NumVulnsB returns the vulnerability in A (the first input to Diff).
+func (s *DiffStats) NumVulnsB() int {
+	return s.numVulnsB
+}
+
+// VulnsANotB returns the vulnerabilities that are A (the first input to Diff) but
+// are not in B (the second input to Diff).
+func (s *DiffStats) VulnsANotB() []string {
+	return s.aNotB
+}
+
+// NumVulnsANotB returns the numbers of vulnerabilities that are A (the first input
+// to Diff) but are not in B (the second input to Diff).
+func (s *DiffStats) NumVulnsANotB() int {
+	return len(s.aNotB)
+}
+
+// VulnsBNotA returns the vulnerabilities that are A (the first input to Diff) but
+// are not in B (the second input to Diff).
+func (s *DiffStats) VulnsBNotA() []string {
+	return s.bNotA
+}
+
+// NumVulnsBNotA returns the numbers of vulnerabilities that are B (the second input
+// to Diff) but are not in A (the first input to Diff).
+func (s *DiffStats) NumVulnsBNotA() int {
+	return len(s.bNotA)
+}
+
+// NumDiffVulns returns the number of vulnerability that are in both A and B but
+// are different (eg. different description, score, ...).
+func (s *DiffStats) NumDiffVulns() int {
+	return len(s.entries)
+}
+
+// NumChunk returns the number of different vulnerabilities that have a specific chunk.
+func (s *DiffStats) NumChunk(chunk ChunkKind) int {
+	return s.bitCounts[chunk.shift()]
+}
+
+// PercentChunk returns the percentage of different vulnerabilities that have a specific chunk.
+func (s *DiffStats) PercentChunk(chunk ChunkKind) float64 {
+	return float64(s.bitCounts[chunk.shift()]) / float64(len(s.entries)) * 100
+}
+
+func diffDetails(s *schema.NVDCVEFeedJSON10DefCVEItem, bit chunk) bag {
+	var v interface{}
+
+	switch bit {
+	case chunkDescription:
+		v = bag{
+			"description": englishDescription(s),
+		}
+	case chunkScore:
+		v = s.Impact
+	}
+
+	var data bag
+	tmp, _ := json.Marshal(v)
+	_ = json.Unmarshal(tmp, &data)
+
+	return data
+}
+
+func genEntryDiffOutput(aFeed, bFeed *diffFeed, entry *diffEntry) []bag {
+	a := aFeed.dict[entry.id].(*nvd.Vuln).Schema()
+	b := bFeed.dict[entry.id].(*nvd.Vuln).Schema()
+	outputs := make([]bag, bits.OnesCount32(uint32(entry.bits)))
+	for i := 0; i < chunkMaxShift; i++ {
+		if entry.bits&(1<<i) != 0 {
+			outputs[i] = bag{
+				"kind":     chunkKind[i],
+				aFeed.name: diffDetails(a, 1<<i),
+				bFeed.name: diffDetails(b, 1<<i),
+			}
+		}
+	}
+	return outputs
+}
+
+// MarshalJSON implements a custom JSON marshaller.
+func (s *DiffStats) MarshalJSON() ([]byte, error) {
+	var differences []bag
+	for _, entry := range s.entries {
+		differences = append(differences, bag{
+			"id":     entry.id,
+			"chunks": genEntryDiffOutput(&s.diff.a, &s.diff.b, &entry),
+		})
+	}
+	return json.Marshal(bag{
+		"differences": differences,
+	})
+}
+
+func englishDescription(s *schema.NVDCVEFeedJSON10DefCVEItem) string {
+	for _, d := range s.CVE.Description.DescriptionData {
+		if d.Lang == "en" {
+			return d.Value
+		}
+	}
+	return ""
+}
+
+func sameDescription(a, b *schema.NVDCVEFeedJSON10DefCVEItem) bool {
+	return englishDescription(a) == englishDescription(b)
+}
+
+func sameScoreCVSSV2(a, b *schema.NVDCVEFeedJSON10DefCVEItem) bool {
+	var aScore, bScore float64
+	var aVector, bVector string
+
+	if a.Impact.BaseMetricV2 != nil && a.Impact.BaseMetricV2.CVSSV2 != nil {
+		aScore = a.Impact.BaseMetricV2.CVSSV2.BaseScore
+		aVector = a.Impact.BaseMetricV2.CVSSV2.VectorString
+	}
+	if b.Impact.BaseMetricV2 != nil && b.Impact.BaseMetricV2.CVSSV2 != nil {
+		bScore = b.Impact.BaseMetricV2.CVSSV2.BaseScore
+		bVector = b.Impact.BaseMetricV2.CVSSV2.VectorString
+	}
+	return aScore == bScore && aVector == bVector
+}
+
+func sameScoreCVSSV3(a, b *schema.NVDCVEFeedJSON10DefCVEItem) bool {
+	var aScore, bScore float64
+	var aVector, bVector string
+
+	if a.Impact.BaseMetricV3 != nil && a.Impact.BaseMetricV3.CVSSV3 != nil {
+		aScore = a.Impact.BaseMetricV3.CVSSV3.BaseScore
+		aVector = a.Impact.BaseMetricV3.CVSSV3.VectorString
+	}
+	if b.Impact.BaseMetricV3 != nil && b.Impact.BaseMetricV3.CVSSV3 != nil {
+		bScore = b.Impact.BaseMetricV3.CVSSV3.BaseScore
+		bVector = b.Impact.BaseMetricV3.CVSSV3.VectorString
+	}
+	return aScore == bScore && aVector == bVector
+}
+
+func sameScore(a, b *schema.NVDCVEFeedJSON10DefCVEItem) bool {
+	return sameScoreCVSSV2(a, b) && sameScoreCVSSV3(a, b)
+}
+
+func (d *diff) stats() *DiffStats {
+	stats := DiffStats{
+		diff:      d,
+		numVulnsA: len(d.a.dict),
+		numVulnsB: len(d.b.dict),
+	}
+
+	// List of vulns that are in a but not in b.
+	for key := range d.a.dict {
+		if _, ok := d.b.dict[key]; !ok {
+			stats.aNotB = append(stats.aNotB, key)
+			continue
+		}
+
+		// key is in both a and b, let's compare further!
+		a := d.a.dict[key].(*nvd.Vuln).Schema()
+		b := d.b.dict[key].(*nvd.Vuln).Schema()
+
+		var entry diffEntry
+
+		if !sameDescription(a, b) {
+			entry.bits |= chunkDescription
+			stats.bitCounts[chunkDescriptionShift]++
+		}
+		if !sameScore(a, b) {
+			entry.bits |= chunkScore
+			stats.bitCounts[chunkScoreShift]++
+		}
+
+		if entry.bits != 0 {
+			entry.id = key
+			stats.entries = append(stats.entries, entry)
+		}
+	}
+
+	// List of vulns that are in b but not in a.
+	for key := range d.b.dict {
+		if _, ok := d.a.dict[key]; !ok {
+			stats.bNotA = append(stats.bNotA, key)
+		}
+	}
+
+	return &stats
+}
+
+// Diff performs a diff between two Dictionaries.
+func Diff(aName string, aDict Dictionary, bName string, bDict Dictionary) *DiffStats {
+	diff := newDiff(diffFeed{aName, aDict}, diffFeed{bName, bDict})
+	return diff.stats()
+}

--- a/cvefeed/nvd/match_cve.go
+++ b/cvefeed/nvd/match_cve.go
@@ -45,6 +45,11 @@ type Vuln struct {
 	wfn.Matcher
 }
 
+// Schema returns the underlying schema of the Vuln
+func (v *Vuln) Schema() *schema.NVDCVEFeedJSON10DefCVEItem {
+	return v.cveItem
+}
+
 // ID is a part of the cvefeed.Vuln Interface
 func (v *Vuln) ID() string {
 	if v == nil || v.cveItem == nil || v.cveItem.CVE == nil || v.cveItem.CVE.CVEDataMeta == nil {


### PR DESCRIPTION
This is the first version of a `diff` command that takes two JSON files from `vulndb export` and compute both status and a set of differences between two prodivers.

```
$ vulndb diff ~/data/nvd.json ~/data/vfeed.json
2020/06/22 17:25:30 diffcmd.go:35: loading /Users/dlespiau/data/nvd.json
2020/06/22 17:25:41 diffcmd.go:35: loading /Users/dlespiau/data/vfeed.json
2020/06/22 17:25:51 diffcmd.go:87: computing stats
Num vulnerabilities in nvd: 145376
Num vulnerabilities in vfeed: 137392
Num vulnerabilities in nvd but not in vfeed: 7984
    CVE-1999-0020
    CVE-1999-0110
    CVE-1999-0187
    CVE-1999-0282
    CVE-1999-0531
    CVE-1999-0614
    CVE-1999-0615
    CVE-1999-0616
    CVE-1999-0617
    CVE-1999-0619
    ... (7974 more)
Num vulnerabilities in vfeed but not in nvd: 0

Different vulnerabilities: 112
    different descriptions: 112 (100.00%, total 0.08%)
    different scores      : 30 (26.79%, total 0.02%)
2020/06/22 17:25:52 diffcmd.go:109: writing differences to stats.json
```

stats.json then contains the list off detected differences between CVEs, eg.

```
    {
      "chunks": [
        {
          "kind": "description",
          "nvd": {
            "description": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
          },
          "vfeed": {
            "description": "UPX 3.95 is affected by: Integer Overflow. The impact is: attacker can cause a denial of service. The component is: src/p_lx_elf.cpp PackLinuxElf32::PackLinuxElf32help1() Line 262. The attack vector is: the victim must open a specially crafted ELF file."
          }
        }
      ],
      "id": "CVE-2019-1010048"
    },
```