### PR TITLE
Allow passing `FLEXERA_TOKEN` env variable without prefixing with "Token"

### DIFF
--- a/cmd/flexera2nvd/flexera2nvd.go
+++ b/cmd/flexera2nvd/flexera2nvd.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/facebookincubator/nvdtools/providers/flexera/api"
 	"github.com/facebookincubator/nvdtools/providers/flexera/schema"
@@ -45,6 +46,9 @@ func FetchSince(ctx context.Context, c client.Client, baseURL string, since int6
 	apiKey := os.Getenv("FLEXERA_TOKEN")
 	if apiKey == "" {
 		return nil, fmt.Errorf("please set FLEXERA_TOKEN in environment")
+	}
+	if !strings.HasPrefix(apiKey, "Token ") {
+		apiKey = "Token " + apiKey
 	}
 
 	client := api.NewClient(c, baseURL, apiKey)


### PR DESCRIPTION
When running `go run ./cmd/flexera2nvd -download -since 2020-08-31T00:00Z` you need to specify `FLEXERA_TOKEN`.

The `FLEXERA_TOKEN` is in the format `Token <actual token>` but setting `FLEXERA_TOKEN="Token <token>"` is a bit counterintuitive so this PR allows passing only the token itself as in `FLEXERA_TOKEN=<token>` and the "Token " part will be prepended if needed.

Tested by manually running the `go run ...` and setting `FLEXERA_TOKEN="Token <token>"` and `FLEXERA_TOKEN="<token>"` and both work.