### PR TITLE
Replacing vulndb `log` calls with flog to output log messages in GLOG format

### DIFF
--- a/cmd/vulndb/customcmd.go
+++ b/cmd/vulndb/customcmd.go
@@ -16,11 +16,11 @@ package main
 
 import (
 	"context"
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/vulndb"
 	"github.com/facebookincubator/nvdtools/vulndb/mysql"
 )
@@ -59,7 +59,7 @@ File schema: https://csrc.nist.gov/schema/nvd/feed/1.0/nvd_cve_feed_json_1.0.sch
 
 		db, err := mysql.OpenWrite(gFlagMySQL)
 		if err != nil {
-			log.Fatalln("cannot open db:", err)
+			flog.Fatalln("cannot open db:", err)
 		}
 		defer db.Close()
 
@@ -72,7 +72,7 @@ File schema: https://csrc.nist.gov/schema/nvd/feed/1.0/nvd_cve_feed_json_1.0.sch
 		ctx := context.Background()
 		err = imp.ImportFile(ctx, args[0])
 		if err != nil {
-			log.Fatal(err)
+			flog.Fatal(err)
 		}
 	},
 }
@@ -97,7 +97,7 @@ for JSON output, e.g. JSON_INDENT=$'\t' or use jq.
 	Run: func(cmd *cobra.Command, args []string) {
 		db, err := mysql.OpenRead(gFlagMySQL)
 		if err != nil {
-			log.Fatalln("cannot open db:", err)
+			flog.Fatalln("cannot open db:", err)
 		}
 		defer db.Close()
 
@@ -114,10 +114,10 @@ for JSON output, e.g. JSON_INDENT=$'\t' or use jq.
 		case "nvdcvejson":
 			err = exp.JSON(ctx, os.Stdout, os.Getenv("JSON_INDENT"))
 		default:
-			log.Fatalln("unsupported format:", gFlagFormat)
+			flog.Fatalln("unsupported format:", gFlagFormat)
 		}
 		if err != nil {
-			log.Fatalln(err)
+			flog.Fatalln(err)
 		}
 	},
 }
@@ -143,7 +143,7 @@ for specific providers. Requires a list of CVE ID to delete, or
 
 		db, err := mysql.OpenWrite(gFlagMySQL)
 		if err != nil {
-			log.Fatalln("cannot open db:", err)
+			flog.Fatalln("cannot open db:", err)
 		}
 		defer db.Close()
 
@@ -156,7 +156,7 @@ for specific providers. Requires a list of CVE ID to delete, or
 		ctx := context.Background()
 		err = del.Delete(ctx)
 		if err != nil {
-			log.Fatalln(err)
+			flog.Fatalln(err)
 		}
 	},
 }

--- a/cmd/vulndb/diffcmd.go
+++ b/cmd/vulndb/diffcmd.go
@@ -19,10 +19,10 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"path/filepath"
 	"sort"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/cvefeed"
 	"github.com/spf13/cobra"
 )
@@ -32,7 +32,7 @@ func init() {
 }
 
 func feedLoad(file string) (cvefeed.Dictionary, error) {
-	log.Printf("loading %s\n", file)
+	flog.Infof("loading %s\n", file)
 	dict, err := cvefeed.LoadJSONDictionary(file)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load dictionary %s: %v", file, err)
@@ -84,7 +84,7 @@ var diffCmd = &cobra.Command{
 			return err
 		}
 
-		log.Println("computing stats")
+		flog.Infoln("computing stats")
 
 		a := feedName(args[0])
 		b := feedName(args[1])
@@ -106,7 +106,7 @@ var diffCmd = &cobra.Command{
 			stats.NumChunk(cvefeed.ChunkScore), stats.PercentChunk(cvefeed.ChunkScore),
 			percentInt(stats.NumChunk(cvefeed.ChunkScore), stats.NumVulnsA()))
 
-		log.Println("writing differences to stats.json")
+		flog.Infoln("writing differences to stats.json")
 
 		data, err := json.MarshalIndent(stats, "", "  ")
 		if err != nil {

--- a/cmd/vulndb/editcmd.go
+++ b/cmd/vulndb/editcmd.go
@@ -21,12 +21,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 
 	"github.com/spf13/cobra"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/vulndb"
 	"github.com/facebookincubator/nvdtools/vulndb/mysql"
 )
@@ -65,18 +65,18 @@ for JSON output, e.g. JSON_INDENT=$'\t' or use jq.
 
 		editor := os.Getenv("EDITOR")
 		if editor == "" {
-			log.Fatalln("$EDITOR not set, cannot edit")
+			flog.Fatalln("$EDITOR not set, cannot edit")
 		}
 
 		db, err := mysql.OpenRead(gFlagMySQL)
 		if err != nil {
-			log.Fatalln("cannot open db:", err)
+			flog.Fatalln("cannot open db:", err)
 		}
 		defer db.Close()
 
 		f, err := ioutil.TempFile("", "vulndb")
 		if err != nil {
-			log.Fatalln("cannot open temp file:", err)
+			flog.Fatalln("cannot open temp file:", err)
 		}
 		defer f.Close()
 
@@ -97,12 +97,12 @@ for JSON output, e.g. JSON_INDENT=$'\t' or use jq.
 		ctx := context.Background()
 		err = exp.JSON(ctx, mw, indent)
 		if err != nil {
-			log.Fatalln(err)
+			flog.Fatalln(err)
 		}
 
 		err = f.Sync()
 		if err != nil {
-			log.Fatalln(err)
+			flog.Fatalln(err)
 		}
 
 		oscmd := exec.Command(editor, f.Name())
@@ -112,17 +112,17 @@ for JSON output, e.g. JSON_INDENT=$'\t' or use jq.
 		err = oscmd.Run()
 		if err != nil {
 			os.Remove(f.Name())
-			log.Fatalln(err)
+			flog.Fatalln(err)
 		}
 
 		_, err = f.Seek(0, io.SeekStart)
 		if err != nil {
-			log.Fatalln(err)
+			flog.Fatalln(err)
 		}
 
 		bb, err := ioutil.ReadAll(f)
 		if err != nil {
-			log.Fatalln(err)
+			flog.Fatalln(err)
 		}
 
 		x, y := srcmd5.Sum(nil), md5.Sum(bb)
@@ -134,7 +134,7 @@ for JSON output, e.g. JSON_INDENT=$'\t' or use jq.
 
 		db, err = mysql.OpenWrite(gFlagMySQL)
 		if err != nil {
-			log.Fatalln("cannot open db:", err)
+			flog.Fatalln("cannot open db:", err)
 		}
 		defer db.Close()
 
@@ -146,8 +146,8 @@ for JSON output, e.g. JSON_INDENT=$'\t' or use jq.
 
 		err = imp.ImportFile(ctx, f.Name())
 		if err != nil {
-			log.Println("temp file:", f.Name())
-			log.Fatalln(err)
+			flog.Infoln("temp file:", f.Name())
+			flog.Fatalln(err)
 		}
 
 		os.Remove(f.Name()) // remove on success

--- a/cmd/vulndb/exportcmd.go
+++ b/cmd/vulndb/exportcmd.go
@@ -16,12 +16,12 @@ package main
 
 import (
 	"context"
-	"log"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/vulndb"
 	"github.com/facebookincubator/nvdtools/vulndb/mysql"
 )
@@ -48,7 +48,7 @@ for JSON output, e.g. JSON_INDENT=$'\t' or use jq.
 	Run: func(cmd *cobra.Command, args []string) {
 		db, err := mysql.OpenRead(gFlagMySQL)
 		if err != nil {
-			log.Fatalln("cannot open db:", err)
+			flog.Fatalln("cannot open db:", err)
 		}
 		defer db.Close()
 
@@ -71,10 +71,10 @@ for JSON output, e.g. JSON_INDENT=$'\t' or use jq.
 		case "nvdcvejson":
 			err = exp.JSON(ctx, os.Stdout, os.Getenv("JSON_INDENT"))
 		default:
-			log.Fatalln("unsupported format:", gFlagFormat)
+			flog.Fatalln("unsupported format:", gFlagFormat)
 		}
 		if err != nil {
-			log.Fatalln(err)
+			flog.Fatalln(err)
 		}
 	},
 }

--- a/cmd/vulndb/main.go
+++ b/cmd/vulndb/main.go
@@ -16,16 +16,14 @@
 package main
 
 import (
-	"log"
-
 	"github.com/spf13/cobra"
+
+  "github.com/facebookincubator/flog"
 )
 
 func main() {
-	log.SetFlags(log.LstdFlags | log.Lshortfile)
-
 	if err := RootCmd.Execute(); err != nil {
-		log.Fatal(err)
+		flog.Fatal(err)
 	}
 }
 

--- a/cmd/vulndb/snoozecmd.go
+++ b/cmd/vulndb/snoozecmd.go
@@ -16,11 +16,11 @@ package main
 
 import (
 	"context"
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/vulndb"
 	"github.com/facebookincubator/nvdtools/vulndb/mysql"
 )
@@ -60,7 +60,7 @@ The deadline and metadata flags are optional.
 
 		db, err := mysql.OpenWrite(gFlagMySQL)
 		if err != nil {
-			log.Fatalln("cannot open db:", err)
+			flog.Fatalln("cannot open db:", err)
 		}
 		defer db.Close()
 
@@ -79,7 +79,7 @@ The deadline and metadata flags are optional.
 		ctx := context.Background()
 		err = sc.Create(ctx, args...)
 		if err != nil {
-			log.Fatalln(err)
+			flog.Fatalln(err)
 		}
 	},
 }
@@ -101,7 +101,7 @@ The --collector and --provider flags, and list of CVEs are optional filters.
 	Run: func(cmd *cobra.Command, args []string) {
 		db, err := mysql.OpenRead(gFlagMySQL)
 		if err != nil {
-			log.Fatalln("cannot open db:", err)
+			flog.Fatalln("cannot open db:", err)
 		}
 		defer db.Close()
 
@@ -115,7 +115,7 @@ The --collector and --provider flags, and list of CVEs are optional filters.
 		ctx := context.Background()
 		err = sg.CSV(ctx, os.Stdout, !gFlagCSVNoHeader)
 		if err != nil {
-			log.Fatalln(err)
+			flog.Fatalln(err)
 		}
 	},
 }
@@ -139,7 +139,7 @@ The delete command deletes snoozes from the database for specific providers.
 
 		db, err := mysql.OpenWrite(gFlagMySQL)
 		if err != nil {
-			log.Fatalln("cannot open db:", err)
+			flog.Fatalln("cannot open db:", err)
 		}
 		defer db.Close()
 
@@ -153,7 +153,7 @@ The delete command deletes snoozes from the database for specific providers.
 		ctx := context.Background()
 		err = del.Delete(ctx)
 		if err != nil {
-			log.Fatalln(err)
+			flog.Fatalln(err)
 		}
 	},
 }

--- a/cmd/vulndb/summarycmd.go
+++ b/cmd/vulndb/summarycmd.go
@@ -16,11 +16,11 @@ package main
 
 import (
 	"context"
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
 
+  "github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/vulndb"
 	"github.com/facebookincubator/nvdtools/vulndb/mysql"
 )
@@ -37,7 +37,7 @@ var summaryCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		db, err := mysql.OpenRead(gFlagMySQL)
 		if err != nil {
-			log.Fatalln("cannot open db:", err)
+			flog.Fatalln("cannot open db:", err)
 		}
 		defer db.Close()
 
@@ -48,7 +48,7 @@ var summaryCmd = &cobra.Command{
 		ctx := context.Background()
 		err = exp.CSV(ctx, os.Stdout, !gFlagCSVNoHeader)
 		if err != nil {
-			log.Fatalln(err)
+			flog.Fatalln(err)
 		}
 	},
 }

--- a/cmd/vulndb/vendorcmd.go
+++ b/cmd/vulndb/vendorcmd.go
@@ -16,12 +16,12 @@ package main
 
 import (
 	"context"
-	"log"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/vulndb"
 	"github.com/facebookincubator/nvdtools/vulndb/mysql"
 )
@@ -61,7 +61,7 @@ File schema: https://csrc.nist.gov/schema/nvd/feed/1.0/nvd_cve_feed_json_1.0.sch
 
 		db, err := mysql.OpenWrite(gFlagMySQL)
 		if err != nil {
-			log.Fatalln("cannot open db:", err)
+			flog.Fatalln("cannot open db:", err)
 		}
 		defer db.Close()
 
@@ -70,17 +70,17 @@ File schema: https://csrc.nist.gov/schema/nvd/feed/1.0/nvd_cve_feed_json_1.0.sch
 			Owner:    gFlagOwner,
 			Provider: gFlagProvider,
 			OnFile: func(name string) {
-				log.Println("importing", name)
+				flog.Infoln("importing", name)
 			},
 		}
 
 		ctx := context.Background()
 		vendor, err := imp.ImportFiles(ctx, args...)
 		if err != nil {
-			log.Fatal(err)
+			flog.Fatal(err)
 		}
 
-		log.Printf("imported %s:%d", vendor.Provider, vendor.Version)
+		flog.Infof("imported %s:%d", vendor.Provider, vendor.Version)
 	},
 }
 
@@ -104,7 +104,7 @@ for JSON output, e.g. JSON_INDENT=$'\t' or use jq.
 	Run: func(cmd *cobra.Command, args []string) {
 		db, err := mysql.OpenRead(gFlagMySQL)
 		if err != nil {
-			log.Fatalln("cannot open db:", err)
+			flog.Fatalln("cannot open db:", err)
 		}
 		defer db.Close()
 
@@ -122,10 +122,10 @@ for JSON output, e.g. JSON_INDENT=$'\t' or use jq.
 		case "nvdcvejson":
 			err = exp.JSON(ctx, os.Stdout, os.Getenv("JSON_INDENT"))
 		default:
-			log.Fatalln("unsupported format:", gFlagFormat)
+			flog.Fatalln("unsupported format:", gFlagFormat)
 		}
 		if err != nil {
-			log.Fatalln(err)
+			flog.Fatalln(err)
 		}
 	},
 }
@@ -150,7 +150,7 @@ To force deleting all data use --all, optionally combined with --provider.
 	Run: func(cmd *cobra.Command, args []string) {
 		db, err := mysql.OpenWrite(gFlagMySQL)
 		if err != nil {
-			log.Fatalln("cannot open db:", err)
+			flog.Fatalln("cannot open db:", err)
 		}
 		defer db.Close()
 
@@ -168,7 +168,7 @@ To force deleting all data use --all, optionally combined with --provider.
 		ctx := context.Background()
 		err = del.Trim(ctx)
 		if err != nil {
-			log.Fatalln(err)
+			flog.Fatalln(err)
 		}
 	},
 }


### PR DESCRIPTION
Changing vulndb's `log` calls with `flog` is the first step towards unifying all our log messages to GLOG format. This will bring consistency to our logs since some utilities use `flog` and others use `log`