### PR TITLE
Write logs in GLOG format

### DIFF
--- a/cmd/csv2cpe/csv2cpe.go
+++ b/cmd/csv2cpe/csv2cpe.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/wfn"
 )
 
@@ -77,8 +78,7 @@ func main() {
 
 	err = p.Process(acm, os.Stdin, os.Stdout)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		flog.Fatalln(err)
 	}
 }
 

--- a/cmd/fireeye2nvd/fireeye2nvd.go
+++ b/cmd/fireeye2nvd/fireeye2nvd.go
@@ -19,9 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/providers/fireeye/api"
 	"github.com/facebookincubator/nvdtools/providers/fireeye/schema"
 	"github.com/facebookincubator/nvdtools/providers/lib/client"
@@ -68,7 +68,6 @@ func main() {
 	}
 
 	if err := r.Run(); err != nil {
-		log.Println(err)
-		os.Exit(1)
+		flog.Fatalln(err)
 	}
 }

--- a/cmd/flexera2nvd/flexera2nvd.go
+++ b/cmd/flexera2nvd/flexera2nvd.go
@@ -19,10 +19,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"strings"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/providers/flexera/api"
 	"github.com/facebookincubator/nvdtools/providers/flexera/schema"
 	"github.com/facebookincubator/nvdtools/providers/lib/client"
@@ -68,7 +68,6 @@ func main() {
 	}
 
 	if err := r.Run(); err != nil {
-		log.Println(err)
-		os.Exit(1)
+		flog.Fatalln(err)
 	}
 }

--- a/cmd/idefense2nvd/idefense2nvd.go
+++ b/cmd/idefense2nvd/idefense2nvd.go
@@ -19,9 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/providers/idefense/api"
 	"github.com/facebookincubator/nvdtools/providers/idefense/schema"
 	"github.com/facebookincubator/nvdtools/providers/lib/client"
@@ -63,7 +63,6 @@ func main() {
 	}
 
 	if err := r.Run(); err != nil {
-		log.Println(err)
-		os.Exit(1)
+		flog.Fatalln(err)
 	}
 }

--- a/cmd/rbs2nvd/rbs2nvd.go
+++ b/cmd/rbs2nvd/rbs2nvd.go
@@ -20,9 +20,9 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"os"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/providers/lib/client"
 	"github.com/facebookincubator/nvdtools/providers/lib/runner"
 	"github.com/facebookincubator/nvdtools/providers/rbs/api"
@@ -77,6 +77,6 @@ func main() {
 	}
 
 	if err := r.Run(); err != nil {
-		log.Println(err)
+		flog.Errorln(err)
 	}
 }

--- a/cmd/redhat2nvd/redhat2nvd.go
+++ b/cmd/redhat2nvd/redhat2nvd.go
@@ -19,9 +19,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
-	"os"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/providers/lib/client"
 	"github.com/facebookincubator/nvdtools/providers/lib/runner"
 	"github.com/facebookincubator/nvdtools/providers/redhat/api"
@@ -59,7 +58,6 @@ func main() {
 	}
 
 	if err := r.Run(); err != nil {
-		log.Println(err)
-		os.Exit(1)
+		flog.Fatalln(err)
 	}
 }

--- a/cmd/snyk2nvd/snyk2nvd.go
+++ b/cmd/snyk2nvd/snyk2nvd.go
@@ -20,10 +20,10 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"strings"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/providers/lib/client"
 	"github.com/facebookincubator/nvdtools/providers/lib/runner"
 	"github.com/facebookincubator/nvdtools/providers/snyk/api"
@@ -76,8 +76,7 @@ func main() {
 	}
 
 	if err := r.Run(); err != nil {
-		log.Println(err)
-		os.Exit(1)
+		flog.Fatalln(err)
 	}
 }
 

--- a/cmd/vfeed2nvd/vfeed2nvd.go
+++ b/cmd/vfeed2nvd/vfeed2nvd.go
@@ -17,11 +17,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 
+	"github.com/facebookincubator/flog"
 	nvd "github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
-
 	"github.com/facebookincubator/nvdtools/providers/vfeed/api"
 )
 
@@ -29,7 +28,7 @@ const pathVar = "VFEED_REPO_PATH"
 
 func main() {
 	if err := run(); err != nil {
-		log.Fatal(err)
+		flog.Fatal(err)
 	}
 }
 

--- a/cmd/wfnconvert/wfnconvert.go
+++ b/cmd/wfnconvert/wfnconvert.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/facebookincubator/flog"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -42,8 +43,7 @@ func main() {
 		flag.Usage()
 	}
 	if err := wfnconvert(os.Stdin, os.Stdout, &o); err != nil {
-		fmt.Fprintf(os.Stderr, "wfnconvert: %v\n", err)
-		os.Exit(1)
+		flog.Fatalf("wfnconvert: %v\n", err)
 	}
 }
 

--- a/providers/fireeye/api/threat.go
+++ b/providers/fireeye/api/threat.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"sync"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/providers/fireeye/schema"
 	"github.com/facebookincubator/nvdtools/stats"
 )
@@ -42,13 +42,13 @@ func (c *Client) FetchAllThreatReportsSince(ctx context.Context, since int64) (<
 		params := params
 		go func() {
 			defer wgReportIDs.Done()
-			log.Printf("Fetching: %s\n", params)
+			flog.Infof("Fetching: %s\n", params)
 			if rIDs, err := c.fetchReportIDs(ctx, params); err == nil {
 				for _, rID := range rIDs {
 					reportIDs <- rID
 				}
 			} else {
-				log.Println(err)
+				flog.Errorln(err)
 			}
 		}()
 	}
@@ -73,7 +73,7 @@ func (c *Client) FetchAllThreatReportsSince(ctx context.Context, since int64) (<
 				reports <- report
 			} else {
 				stats.IncrementCounter("report.error")
-				log.Println(err)
+				flog.Errorln(err)
 			}
 		}()
 	}

--- a/providers/fireeye/api/vulnerability.go
+++ b/providers/fireeye/api/vulnerability.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/providers/fireeye/schema"
 	"github.com/facebookincubator/nvdtools/providers/lib/client"
 	"github.com/facebookincubator/nvdtools/providers/lib/runner"
@@ -40,13 +40,13 @@ func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-ch
 	for _, params := range parameters.batchBy(ninetyDays) {
 		params := params
 		eg.Go(func() error {
-			log.Printf("Fetching: %s\n", params)
+			flog.Infof("Fetching: %s\n", params)
 			vs, err := c.fetchVulnerabilities(ctx, params)
 			if err != nil {
 				return client.StopOrContinue(fmt.Errorf("error while fetching %s: %v", params, err))
 			}
 			numVulns := len(vs)
-			log.Printf("Adding %d vulns\n", numVulns)
+			flog.Infof("Adding %d vulns\n", numVulns)
 			stats.IncrementCounterBy("vulnerabilities", int64(numVulns))
 			for _, v := range vs {
 				output <- v
@@ -57,7 +57,7 @@ func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-ch
 
 	go func() {
 		if err := eg.Wait(); err != nil {
-			log.Println(err)
+			flog.Errorln(err)
 		}
 		close(output)
 	}()

--- a/providers/fireeye/schema/convertutils.go
+++ b/providers/fireeye/schema/convertutils.go
@@ -15,11 +15,11 @@
 package schema
 
 import (
-	"log"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/facebookincubator/flog"
 	nvd "github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
 )
 
@@ -46,7 +46,7 @@ func convertTime(fireeyeTime int64) string {
 func strToFloat(str string) float64 {
 	f, err := strconv.ParseFloat(str, 64)
 	if err != nil {
-		log.Println(err)
+		flog.Errorln(err)
 		f = float64(0)
 	}
 	return f

--- a/providers/flexera/api/client.go
+++ b/providers/flexera/api/client.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"time"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/providers/flexera/schema"
 	"github.com/facebookincubator/nvdtools/providers/lib/client"
 	"github.com/facebookincubator/nvdtools/providers/lib/runner"
@@ -68,7 +68,7 @@ func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-ch
 	mainCtx, cancel := context.WithCancel(ctx)
 
 	numPages := (totalAdvisories-1)/pageSize + 1
-	log.Printf("starting sync for %d advisories over %d pages\n", totalAdvisories, numPages)
+	flog.Infof("starting sync for %d advisories over %d pages\n", totalAdvisories, numPages)
 
 	identifiers := make(chan string, totalAdvisories)
 	advisories := make(chan runner.Convertible, totalAdvisories)
@@ -90,7 +90,7 @@ func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-ch
 
 	go func() {
 		if err := identifersEg.Wait(); err != nil {
-			log.Println(err)
+			flog.Errorln(err)
 			cancel()
 		}
 		close(identifiers)
@@ -112,7 +112,7 @@ func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-ch
 
 	go func() {
 		if err := advisoriesEg.Wait(); err != nil {
-			log.Println(err)
+			flog.Errorln(err)
 			cancel()
 		}
 		close(advisories)

--- a/providers/idefense/api/client.go
+++ b/providers/idefense/api/client.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"time"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/providers/idefense/schema"
 	"github.com/facebookincubator/nvdtools/providers/lib/client"
 	"github.com/facebookincubator/nvdtools/providers/lib/runner"
@@ -73,7 +73,7 @@ func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-ch
 	numPages := (totalVulns-1)/pageSize + 1
 
 	// fetch pages concurrently
-	log.Printf("starting sync for %d vulnerabilities over %d pages\n", totalVulns, numPages)
+	flog.Infof("starting sync for %d vulnerabilities over %d pages\n", totalVulns, numPages)
 	eg, ctx := errgroup.WithContext(ctx)
 	for page := 1; page <= numPages; page++ {
 		page := page
@@ -98,7 +98,7 @@ func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-ch
 
 	go func() {
 		if err := eg.Wait(); err != nil {
-			log.Println(err)
+			flog.Errorln(err)
 		}
 		close(output)
 	}()

--- a/providers/idefense/schema/convertutils.go
+++ b/providers/idefense/schema/convertutils.go
@@ -15,9 +15,9 @@
 package schema
 
 import (
-	"log"
 	"time"
 
+	"github.com/facebookincubator/flog"
 	nvd "github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
 	"github.com/facebookincubator/nvdtools/wfn"
 )
@@ -57,7 +57,7 @@ func (item *Vulnerability) findConfigurations() []configuration {
 	for _, vulnTech := range item.Affects.VulnTechs {
 		attrs, err := createAttributes(vulnTech.Part, vulnTech.Vendor, vulnTech.Product)
 		if err != nil {
-			log.Println(err)
+			flog.Errorln(err)
 			continue
 		}
 		cpe23Uri := attrs.BindToFmtString()
@@ -77,7 +77,7 @@ func (item *Vulnerability) findConfigurations() []configuration {
 	for _, pkg := range item.Affects.Packages {
 		attrs, err := createAttributes("a", "", pkg.PackageName)
 		if err != nil {
-			log.Println(err)
+			flog.Errorln(err)
 			continue
 		}
 		cpe23Uri := attrs.BindToFmtString()
@@ -101,7 +101,7 @@ func (item *Vulnerability) findConfigurations() []configuration {
 	for _, vulnTech := range item.FixedBy.VulnTechs {
 		attrs, err := createAttributes(vulnTech.Part, vulnTech.Vendor, vulnTech.Product)
 		if err != nil {
-			log.Println(err)
+			flog.Errorln(err)
 			continue
 		}
 		cpe23Uri := attrs.BindToFmtString()
@@ -117,7 +117,7 @@ func (item *Vulnerability) findConfigurations() []configuration {
 	for _, pkg := range item.FixedBy.Packages {
 		attrs, err := createAttributes("a", "", pkg.PackageName)
 		if err != nil {
-			log.Println(err)
+			flog.Errorln(err)
 			continue
 		}
 		cpe23Uri := attrs.BindToFmtString()

--- a/providers/lib/client/debug.go
+++ b/providers/lib/client/debug.go
@@ -16,12 +16,13 @@ package client
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httputil"
 	"os"
 	"strconv"
 	"sync/atomic"
+
+	"github.com/facebookincubator/flog"
 )
 
 var debug struct {
@@ -111,7 +112,7 @@ func traceRequestEnd(id uint64, resp *http.Response) {
 // want the pending requests to continue being processed).
 func StopOrContinue(err error) error {
 	if debug.continueDownloading {
-		log.Println(err)
+		flog.Errorln(err)
 		return nil
 	}
 	return err

--- a/providers/rbs/api/client.go
+++ b/providers/rbs/api/client.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/url"
 	"sync"
 	"time"
@@ -26,6 +25,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/providers/lib/client"
 	"github.com/facebookincubator/nvdtools/providers/lib/runner"
 	"github.com/facebookincubator/nvdtools/providers/rbs/schema"
@@ -99,7 +99,7 @@ func (c *Client) fetchAllVulnerabilities(getEndpoint func() string) (<-chan runn
 	numPages := (totalVulns-1)/pageSize + 1
 
 	// fetch pages concurrently
-	log.Printf("starting sync for %d vulnerabilities over %d pages\n", totalVulns, numPages)
+	flog.Infof("starting sync for %d vulnerabilities over %d pages\n", totalVulns, numPages)
 	wg := sync.WaitGroup{}
 	for page := 1; page <= numPages; page++ {
 		page := page
@@ -108,7 +108,7 @@ func (c *Client) fetchAllVulnerabilities(getEndpoint func() string) (<-chan runn
 			defer wg.Done()
 			result, err := fetch(page, pageSize)
 			if err != nil {
-				log.Printf("failed to get page %d: %v", page, err)
+				flog.Errorf("failed to get page %d: %v", page, err)
 				return
 			}
 			for _, vuln := range result.Vulnerabilities {

--- a/providers/rbs/schema/convert.go
+++ b/providers/rbs/schema/convert.go
@@ -16,9 +16,9 @@ package schema
 
 import (
 	"fmt"
-	"log"
 	"time"
 
+	"github.com/facebookincubator/flog"
 	nvd "github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
 	"github.com/facebookincubator/nvdtools/wfn"
 )
@@ -106,7 +106,7 @@ func (item *Vulnerability) makeConfigurations() *nvd.NVDCVEFeedJSON10DefConfigur
 				for _, cpe := range version.CPEs {
 					c, err := normalizeCPE(cpe.CPE)
 					if err != nil {
-						log.Printf("couldn't normalize cpe %q: %v", cpe.CPE, err)
+						flog.Errorf("couldn't normalize cpe %q: %v", cpe.CPE, err)
 						continue
 					}
 					match := &nvd.NVDCVEFeedJSON10DefCPEMatch{

--- a/providers/redhat/api/client.go
+++ b/providers/redhat/api/client.go
@@ -18,13 +18,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
 	"sync"
 	"time"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/providers/lib/client"
 	"github.com/facebookincubator/nvdtools/providers/lib/runner"
 	"github.com/facebookincubator/nvdtools/providers/redhat/schema"
@@ -58,10 +58,10 @@ func (c *Client) FetchAllCVEs(ctx context.Context, since int64) (<-chan runner.C
 			wg.Add(1)
 			go func(cveid string) {
 				defer wg.Done()
-				log.Printf("\tfetching cve %s", cveid)
+				flog.Infof("\tfetching cve %s", cveid)
 				cve, err := c.FetchCVE(ctx, cveid)
 				if err != nil {
-					log.Printf("error while fetching cve %s: %v", cveid, err)
+					flog.Errorf("error while fetching cve %s: %v", cveid, err)
 					return
 				}
 				output <- cve
@@ -98,14 +98,14 @@ func (c *Client) fetchAllPages(ctx context.Context, since int64) <-chan *schema.
 	go func() {
 		defer close(output)
 		for page := 1; ; page++ {
-			log.Printf("fetching page %d", page)
+			flog.Infof("fetching page %d", page)
 			if list, err := c.fetchListPage(ctx, since, page); err == nil {
 				output <- list
 				if len(*list) < perPage {
 					break
 				}
 			} else {
-				log.Printf("can't fetch page %d: %v", page, err)
+				flog.Errorf("can't fetch page %d: %v", page, err)
 				break
 			}
 		}

--- a/providers/redhat/schema/convertutils.go
+++ b/providers/redhat/schema/convertutils.go
@@ -16,11 +16,11 @@ package schema
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/facebookincubator/flog"
 	nvd "github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
 	"github.com/facebookincubator/nvdtools/rpm"
 	"github.com/facebookincubator/nvdtools/wfn"
@@ -41,7 +41,7 @@ func convertTime(redhatTime string) (string, error) {
 		t, err = time.Parse(timeLayout, redhatTime)
 	}
 	if err != nil { // should be parsable
-		log.Printf("unable to parse time: %v", err)
+		flog.Errorf("unable to parse time: %v", err)
 		return redhatTime, err
 	}
 	return t.Format(nvd.TimeLayout), nil
@@ -69,7 +69,7 @@ func IsFixed(fixState string) bool {
 	case "not affected":
 		return true
 	default:
-		log.Printf("unknown fix state: %q", fixState)
+		flog.Infof("unknown fix state: %q", fixState)
 		return false
 	}
 }

--- a/providers/snyk/api/client.go
+++ b/providers/snyk/api/client.go
@@ -19,11 +19,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/providers/lib/client"
 	"github.com/facebookincubator/nvdtools/providers/snyk/schema"
 )
@@ -57,7 +57,7 @@ func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-ch
 		defer content.Close()
 		var advisories schema.Advisories
 		if err := json.NewDecoder(content).Decode(&advisories); err != nil {
-			log.Printf("can't decode content into advisories: %v", err)
+			flog.Errorf("can't decode content into advisories: %v", err)
 			return
 		}
 		for _, advs := range advisories {

--- a/providers/snyk/schema/convert.go
+++ b/providers/snyk/schema/convert.go
@@ -15,8 +15,7 @@
 package schema
 
 import (
-	"log"
-
+	"github.com/facebookincubator/flog"
 	nvd "github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
 	"github.com/facebookincubator/nvdtools/wfn"
 )
@@ -119,7 +118,7 @@ func (advisory *Advisory) newConfigurations() *nvd.NVDCVEFeedJSON10DefConfigurat
 	var err error
 	var product string
 	if product, err = wfn.WFNize(advisory.Package); err != nil {
-		log.Printf("can't wfnize %q\n", advisory.Package)
+		flog.Errorf("can't wfnize %q\n", advisory.Package)
 		product = advisory.Package
 	}
 	cpe := wfn.Attributes{Part: "a", Product: product}
@@ -128,7 +127,7 @@ func (advisory *Advisory) newConfigurations() *nvd.NVDCVEFeedJSON10DefConfigurat
 	for _, versions := range advisory.VulnerableVersions {
 		vRanges, err := parseVersionRange(versions)
 		if err != nil {
-			log.Printf("could not generate configuration for item %s, vulnerable ver %q: %v", advisory.SnykID, versions, err)
+			flog.Errorf("could not generate configuration for item %s, vulnerable ver %q: %v", advisory.SnykID, versions, err)
 			continue
 		}
 		for _, vRange := range vRanges {

--- a/providers/snyk/schema/time.go
+++ b/providers/snyk/schema/time.go
@@ -15,9 +15,9 @@
 package schema
 
 import (
-	"log"
 	"time"
 
+	"github.com/facebookincubator/flog"
 	nvd "github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
 )
 
@@ -37,6 +37,6 @@ func snykTimeToNVD(s string) string {
 		}
 	}
 
-	log.Printf("cannot parse snyk time: %v", err)
+	flog.Errorf("cannot parse snyk time: %v", err)
 	return s
 }

--- a/providers/vfeed/api/client.go
+++ b/providers/vfeed/api/client.go
@@ -19,9 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"path/filepath"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/providers/vfeed/schema"
 )
 
@@ -56,7 +56,7 @@ func (c *Client) FetchAllVulnerabilities(since int64) (<-chan *schema.Item, erro
 
 			item, err := unmarshalFile(match)
 			if err != nil {
-				log.Printf("Failed to unmarshal %s: %v", match, err)
+				flog.Errorf("Failed to unmarshal %s: %v", match, err)
 				return
 			}
 

--- a/providers/vfeed/schema/convert_test.go
+++ b/providers/vfeed/schema/convert_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"path"
 	"path/filepath"
 	"reflect"
@@ -27,6 +26,7 @@ import (
 
 	"github.com/andreyvit/diff"
 
+	"github.com/facebookincubator/flog"
 	nvd "github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
 )
 
@@ -80,7 +80,7 @@ func checkSchema(t *testing.T, input, expected string) {
 
 	item := &Item{}
 	if err := unmarshalFile(item, input); err != nil {
-		log.Fatalf("Failed to unmarshal example file: %v", err)
+		flog.Fatalf("Failed to unmarshal example file: %v", err)
 	}
 
 	want := &nvd.NVDCVEFeedJSON10DefCVEItem{}

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -19,10 +19,11 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/facebookincubator/flog"
 )
 
 // Stats encapsulates functionallity of incrementing counters and incrementing values
@@ -131,7 +132,7 @@ func (s *Stats) Write() error {
 // WriteAndLogError is just a wrapper around Write which also logs the error to stderr if it occurs
 func (s *Stats) WriteAndLogError() {
 	if err := s.Write(); err != nil {
-		log.Printf("failed to write stats: %v", err)
+		flog.Errorf("failed to write stats: %v", err)
 	}
 }
 


### PR DESCRIPTION
Unify log messages of the following binaries to GLOG format:
- csv2cpe
- fireeye2nvd
- flexera2nvd
- idefense2nvd
- rbs2nvd
- redhat2nvd
- snyk2nvd
- vfeed2nvd
- wfnconvert

From now on, they all use `flog` instead of `log` and `fmt.Fprint*(os.Stderr,...)`, so nvdtools' logs are more consistent.