### PR TITLE
Fix index out of range panic in `wfn.UnbindFmtString()`

### DIFF
--- a/wfn/fsb.go
+++ b/wfn/fsb.go
@@ -137,6 +137,9 @@ func addSlashesAt(s string, at int) (string, int, error) {
 		switch c {
 		case '\\':
 			i++
+			if i == len(s) {
+				return "", i, fmt.Errorf("unquoted '\\' at the end of the FSB fragment: %q", s)
+			}
 			b = append(b, c, s[i])
 			embedded = true
 		case '*':

--- a/wfn/fsb_test.go
+++ b/wfn/fsb_test.go
@@ -46,6 +46,10 @@ func TestUnbindFmtString(t *testing.T) {
 			Expect: `wfn:[part="a",vendor="foo\\bar",product="big\$money",version="2010",update=ANY,edition=ANY,sw_edition="special",target_sw="ipod_touch",target_hw="80gb",other=ANY,language=ANY]`,
 		},
 		{
+			FSB:  `cpe:2.3:a:cisco:cisco_security_monitoring\`,
+			Fail: true,
+		},
+		{
 			FSB:  `cpe:2.3:a:disney:where\\'s_my_perry?_free:1.5.1:*:*:*:*:android:*:*`,
 			Fail: true,
 		},


### PR DESCRIPTION
The panic was caused by malformed CPE names with unquoted '\' at the end of a fragment.

Before:
```
wfn $ go test
addSlashesAt(cpe:2.3:a:cisco:cisco_security_monitoring\, 16)
--- FAIL: TestUnbindFmtString (0.00s)
    --- FAIL: TestUnbindFmtString/cpe:2.3:a:cisco:cisco_security_monitoring\ (0.00s)
panic: runtime error: index out of range [42] with length 42 [recovered]
        panic: runtime error: index out of range [42] with length 42

goroutine 12 [running]:
testing.tRunner.func1.1(0x113f140, 0xc000012500)
        /usr/local/go/src/testing/testing.go:941 +0x3d0
testing.tRunner.func1(0xc00011c900)
        /usr/local/go/src/testing/testing.go:944 +0x3f9
panic(0x113f140, 0xc000012500)
        /usr/local/go/src/runtime/panic.go:967 +0x166
github.com/facebookincubator/nvdtools/wfn.addSlashesAt(0x11582b0, 0x2a, 0x10, 0xc000010578, 0x5, 0xf, 0x0, 0x0)
        /Users/dvl/go/src/github.com/facebookincubator/nvdtools/wfn/fsb.go:144 +0x943
github.com/facebookincubator/nvdtools/wfn.unbindValueFSAt(0x11582b0, 0x2a, 0x10, 0xc000010578, 0x5, 0xf, 0x0, 0x0)
        /Users/dvl/go/src/github.com/facebookincubator/nvdtools/wfn/fsb.go:124 +0x1ca
github.com/facebookincubator/nvdtools/wfn.UnbindFmtString(0x11582b0, 0x2a, 0x24, 0x37e, 0xc00004a670)
        /Users/dvl/go/src/github.com/facebookincubator/nvdtools/wfn/fsb.go:59 +0x34a
github.com/facebookincubator/nvdtools/wfn.TestUnbindFmtString.func1(0xc00011c900)
        /Users/dvl/go/src/github.com/facebookincubator/nvdtools/wfn/fsb_test.go:64 +0x50
testing.tRunner(0xc00011c900, 0xc000072420)
        /usr/local/go/src/testing/testing.go:992 +0xdc
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1043 +0x357
exit status 2
FAIL    github.com/facebookincubator/nvdtools/wfn       0.201s
```

After:
```
wfn $ go test
PASS
ok      github.com/facebookincubator/nvdtools/wfn       0.322s
```