### PR TITLE
nvd: Display the CVE ID in matching error messages

### DIFF
--- a/cvefeed/nvd/match_cpe.go
+++ b/cvefeed/nvd/match_cpe.go
@@ -33,10 +33,10 @@ type cpeMatch struct {
 }
 
 // Matcher returns an object which knows how to match attributes
-func cpeMatcher(nvdMatch *schema.NVDCVEFeedJSON10DefCPEMatch) (wfn.Matcher, error) {
+func cpeMatcher(ID string, nvdMatch *schema.NVDCVEFeedJSON10DefCPEMatch) (wfn.Matcher, error) {
 	parse := func(uri string) (*wfn.Attributes, error) {
 		if uri == "" {
-			return nil, fmt.Errorf("can't parse empty uri")
+			return nil, fmt.Errorf("%s: can't parse empty uri", ID)
 		}
 		return wfn.Parse(uri)
 	}
@@ -46,7 +46,7 @@ func cpeMatcher(nvdMatch *schema.NVDCVEFeedJSON10DefCPEMatch) (wfn.Matcher, erro
 	var err error
 	if match.Attributes, err = parse(nvdMatch.Cpe23Uri); err != nil {
 		if match.Attributes, err = parse(nvdMatch.Cpe22Uri); err != nil {
-			return nil, fmt.Errorf("unable to parse both cpe2.2 and cpe2.3")
+			return nil, fmt.Errorf("%s: unable to parse both cpe2.2 and cpe2.3", ID)
 		}
 	}
 

--- a/cvefeed/nvd/match_cve.go
+++ b/cvefeed/nvd/match_cve.go
@@ -24,19 +24,21 @@ import (
 var cveRegex = regexp.MustCompile("CVE-[0-9]{4}-[0-9]{4,}")
 
 func ToVuln(cve *schema.NVDCVEFeedJSON10DefCVEItem) *Vuln {
+	vuln := &Vuln{
+		cveItem: cve,
+	}
+
 	var ms []wfn.Matcher
 	for _, node := range cve.Configurations.Nodes {
 		if node != nil {
-			if m, err := nodeMatcher(node); err == nil {
+			if m, err := nodeMatcher(vuln.ID(), node); err == nil {
 				ms = append(ms, m)
 			}
 		}
 	}
+	vuln.Matcher = wfn.MatchAny(ms...)
 
-	return &Vuln{
-		cveItem: cve,
-		Matcher: wfn.MatchAny(ms...),
-	}
+	return vuln
 }
 
 // Vuln implements the cvefeed.Vuln interface

--- a/cvefeed/nvd/match_node.go
+++ b/cvefeed/nvd/match_node.go
@@ -24,36 +24,36 @@ import (
 )
 
 // Matcher returns an object which knows how to match attributes
-func nodeMatcher(node *schema.NVDCVEFeedJSON10DefNode) (wfn.Matcher, error) {
+func nodeMatcher(ID string, node *schema.NVDCVEFeedJSON10DefNode) (wfn.Matcher, error) {
 	if node == nil {
-		return nil, fmt.Errorf("node is nil")
+		return nil, fmt.Errorf("%s: node is nil", ID)
 	}
 
 	var ms []wfn.Matcher
 	for _, match := range node.CPEMatch {
 		if match != nil {
-			if m, err := cpeMatcher(match); err == nil {
+			if m, err := cpeMatcher(ID, match); err == nil {
 				ms = append(ms, m)
 			}
 		}
 	}
 	for _, child := range node.Children {
 		if child != nil {
-			if m, err := nodeMatcher(child); err == nil {
+			if m, err := nodeMatcher(ID, child); err == nil {
 				ms = append(ms, m)
 			}
 		}
 	}
 
 	if len(ms) == 0 {
-		return nil, fmt.Errorf("empty configuration for node")
+		return nil, fmt.Errorf("%s: empty configuration for node", ID)
 	}
 
 	var m wfn.Matcher
 
 	switch strings.ToUpper(node.Operator) {
 	default:
-		log.Printf("unknown operator, defaulting to OR: got %q", node.Operator)
+		log.Printf("%s: unknown operator, defaulting to OR: got %q", ID, node.Operator)
 		fallthrough
 	case "OR":
 		m = wfn.MatchAny(ms...)


### PR DESCRIPTION
When loading a feed I noticed a message such as:

```
2021/03/30 09:12:37 unknown operator, defaulting to OR: got ""
```

That's not really useful in the middle of a big feed of CVE data though. This
commit adds the CVE ID to the error message:

```
2021/03/30 17:08:24 CVE-2021-21166: unknown operator, defaulting to OR: got ""
```

(the NVD data for CVE-2021-21166 is fine, this was for an internally generated
feed/CVE ID)