### PR TITLE
Replacing remaining log calls with flog for GLOG formatting

### DIFF
--- a/cvefeed/nvd/match_node.go
+++ b/cvefeed/nvd/match_node.go
@@ -16,10 +16,10 @@ package nvd
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/wfn"
 )
 
@@ -53,7 +53,7 @@ func nodeMatcher(ID string, node *schema.NVDCVEFeedJSON10DefNode) (wfn.Matcher, 
 
 	switch strings.ToUpper(node.Operator) {
 	default:
-		log.Printf("%s: unknown operator, defaulting to OR: got %q", ID, node.Operator)
+		flog.Warningf("%s: unknown operator, defaulting to OR: got %q", ID, node.Operator)
 		fallthrough
 	case "OR":
 		m = wfn.MatchAny(ms...)

--- a/providers/redhat/package_feed.go
+++ b/providers/redhat/package_feed.go
@@ -15,9 +15,9 @@
 package redhat
 
 import (
-	"log"
 	"sort"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/providers/redhat/schema"
 	"github.com/facebookincubator/nvdtools/rpm"
 	"github.com/facebookincubator/nvdtools/wfn"
@@ -59,7 +59,7 @@ func (feed *Feed) packageFeed() packageFeed {
 			// Failing to parse a package isn't fatal, but we want to surface the error
 			rpmPkg, err := rpm.Parse(ar.Package)
 			if err != nil {
-				log.Printf("feed: failed to parse package: %q", ar.Package)
+				flog.Errorf("feed: failed to parse package: %q", ar.Package)
 				continue
 			}
 			pkgs = addPackage(pkgs, rpmPkg.Name)

--- a/vulndb/custom.go
+++ b/vulndb/custom.go
@@ -19,13 +19,13 @@ import (
 	"database/sql"
 	"encoding/csv"
 	"io"
-	"log"
 	"os"
 	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/vulndb/debug"
 	"github.com/facebookincubator/nvdtools/vulndb/sqlutil"
 )
@@ -105,7 +105,7 @@ func (o CustomDataImporter) importData(ctx context.Context, data []CustomDataRec
 	query, args := q.String(), q.QueryArgs()
 
 	if debug.V(2) {
-		log.Printf("running: %q", query)
+		flog.Infof("running: %q", query)
 	}
 
 	_, err := o.DB.ExecContext(ctx, query, args...)
@@ -153,7 +153,7 @@ func (o CustomDataExporter) CSV(ctx context.Context, w io.Writer, header bool) e
 	query, args := q.String(), q.QueryArgs()
 
 	if debug.V(1) {
-		log.Printf("running: %q / %#v", query, args)
+		flog.Infof("running: %q / %#v", query, args)
 	}
 
 	rows, err := o.DB.QueryContext(ctx, query, args...)
@@ -206,7 +206,7 @@ func (o CustomDataExporter) JSON(ctx context.Context, w io.Writer, indent string
 	query, args := q.String(), q.QueryArgs()
 
 	if debug.V(1) {
-		log.Printf("running: %q / %#v", query, args)
+		flog.Infof("running: %q / %#v", query, args)
 	}
 
 	rows, err := o.DB.QueryContext(ctx, query, args...)
@@ -262,7 +262,7 @@ func (o CustomDataDeleter) Delete(ctx context.Context) error {
 	query, args := q.String(), q.QueryArgs()
 
 	if debug.V(1) {
-		log.Printf("running: %q / %#v", query, args)
+		flog.Infof("running: %q / %#v", query, args)
 	}
 
 	_, err := o.DB.ExecContext(ctx, query, args...)

--- a/vulndb/export.go
+++ b/vulndb/export.go
@@ -19,12 +19,12 @@ import (
 	"database/sql"
 	"encoding/csv"
 	"io"
-	"log"
 	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/vulndb/debug"
 	"github.com/facebookincubator/nvdtools/vulndb/sqlutil"
 )
@@ -140,7 +140,7 @@ func (exp DataExporter) CSV(ctx context.Context, w io.Writer, header bool) error
 	query, args := q.String(), q.QueryArgs()
 
 	if debug.V(1) {
-		log.Printf("running: %q / %#v", query, args)
+		flog.Infof("running: %q / %#v", query, args)
 	}
 
 	rows, err := exp.DB.QueryContext(ctx, query, args...)
@@ -210,7 +210,7 @@ func (exp DataExporter) JSON(ctx context.Context, w io.Writer, indent string) er
 	query, args := q.String(), q.QueryArgs()
 
 	if debug.V(1) {
-		log.Printf("running: %q / %#v", query, args)
+		flog.Infof("running: %q / %#v", query, args)
 	}
 
 	rows, err := exp.DB.QueryContext(ctx, query, args...)

--- a/vulndb/mysql/mysql.go
+++ b/vulndb/mysql/mysql.go
@@ -17,10 +17,10 @@ package mysql
 
 import (
 	"database/sql"
-	"log"
 	"net/url"
 	"time"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/vulndb/debug"
 )
 
@@ -44,7 +44,7 @@ func openDB(dsn string) (*sql.DB, error) {
 		"charset":   []string{"utf8mb4"},
 	})
 	if debug.V(1) {
-		log.Printf("connecting to %q", dsn)
+		flog.Infof("connecting to %q", dsn)
 	}
 	db, err := sql.Open(mysqlDriver, dsn)
 	if err != nil {

--- a/vulndb/snooze.go
+++ b/vulndb/snooze.go
@@ -19,11 +19,11 @@ import (
 	"database/sql"
 	"encoding/csv"
 	"io"
-	"log"
 	"time"
 
 	"github.com/pkg/errors"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/vulndb/debug"
 	"github.com/facebookincubator/nvdtools/vulndb/sqlutil"
 )
@@ -73,7 +73,7 @@ func (s SnoozeCreator) Create(ctx context.Context, cve ...string) error {
 	query, args := q.String(), q.QueryArgs()
 
 	if debug.V(1) {
-		log.Printf("running: %q / %#v", query, args)
+		flog.Infof("running: %q / %#v", query, args)
 	}
 
 	_, err := s.DB.ExecContext(ctx, query, args...)
@@ -132,7 +132,7 @@ func (s SnoozeGetter) CSV(ctx context.Context, w io.Writer, header bool) error {
 	query, args := q.String(), q.QueryArgs()
 
 	if debug.V(1) {
-		log.Printf("running: %q / %#v", query, args)
+		flog.Infof("running: %q / %#v", query, args)
 	}
 
 	rows, err := s.DB.QueryContext(ctx, query, args...)
@@ -198,7 +198,7 @@ func (s SnoozeDeleter) Delete(ctx context.Context) error {
 	query, args := q.String(), q.QueryArgs()
 
 	if debug.V(1) {
-		log.Printf("running: %q / %#v", query, args)
+		flog.Infof("running: %q / %#v", query, args)
 	}
 
 	_, err := s.DB.ExecContext(ctx, query, args...)

--- a/vulndb/summary.go
+++ b/vulndb/summary.go
@@ -19,12 +19,12 @@ import (
 	"database/sql"
 	"encoding/csv"
 	"io"
-	"log"
 	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/vulndb/debug"
 	"github.com/facebookincubator/nvdtools/vulndb/sqlutil"
 )
@@ -51,7 +51,7 @@ func (exp SummaryExporter) SummaryRecords(ctx context.Context) ([]SummaryRecord,
 	query := summaryQuery
 
 	if debug.V(1) {
-		log.Printf("running: %q", query)
+		flog.Infof("running: %q", query)
 	}
 
 	rows, err := exp.DB.QueryContext(ctx, query)

--- a/vulndb/vendor.go
+++ b/vulndb/vendor.go
@@ -19,12 +19,12 @@ import (
 	"database/sql"
 	"encoding/csv"
 	"io"
-	"log"
 	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
 
+	"github.com/facebookincubator/flog"
 	"github.com/facebookincubator/nvdtools/vulndb/debug"
 	"github.com/facebookincubator/nvdtools/vulndb/sqlutil"
 )
@@ -112,7 +112,7 @@ func (v VendorDataImporter) newVersion(ctx context.Context, owner, provider stri
 	query, args := q.String(), q.QueryArgs()
 
 	if debug.V(1) {
-		log.Printf("running: %q / %#v", query, args)
+		flog.Infof("running: %q / %#v", query, args)
 	}
 
 	res, err := v.DB.ExecContext(ctx, query, args...)
@@ -138,7 +138,7 @@ func (v VendorDataImporter) replaceVendorData(ctx context.Context, records sqlut
 	query, args := q.String(), q.QueryArgs()
 
 	if debug.V(2) {
-		log.Printf("running: %q", query)
+		flog.Infof("running: %q", query)
 	}
 
 	_, err := v.DB.ExecContext(ctx, query, args...)
@@ -207,7 +207,7 @@ func (v VendorDataImporter) enableVersion(ctx context.Context, vendor *VendorRec
 	query, args := q.String(), q.QueryArgs()
 
 	if debug.V(1) {
-		log.Printf("running: %q / %#v", query, args)
+		flog.Infof("running: %q / %#v", query, args)
 	}
 
 	_, err := v.DB.ExecContext(ctx, query, args...)
@@ -290,7 +290,7 @@ func (v VendorDataExporter) CSV(ctx context.Context, w io.Writer, header bool) e
 	query, args := q.String(), q.QueryArgs()
 
 	if debug.V(1) {
-		log.Printf("running: %q / %#v", query, args)
+		flog.Infof("running: %q / %#v", query, args)
 	}
 
 	rows, err := v.DB.QueryContext(ctx, query, args...)
@@ -359,7 +359,7 @@ func (v VendorDataExporter) JSON(ctx context.Context, w io.Writer, indent string
 	query, args := q.String(), q.QueryArgs()
 
 	if debug.V(1) {
-		log.Printf("running: %q / %#v", query, args)
+		flog.Infof("running: %q / %#v", query, args)
 	}
 
 	rows, err := v.DB.QueryContext(ctx, query, args...)
@@ -453,7 +453,7 @@ func (v VendorDataTrimmer) deleteVendors(ctx context.Context) error {
 	query, args := q.String(), q.QueryArgs()
 
 	if debug.V(1) {
-		log.Printf("running: %q / %#v", query, args)
+		flog.Infof("running: %q / %#v", query, args)
 	}
 
 	_, err = v.DB.ExecContext(ctx, query, args...)
@@ -483,7 +483,7 @@ func (v VendorDataTrimmer) deleteOrphanData(ctx context.Context) error {
 	query, args := q.String(), q.QueryArgs()
 
 	if debug.V(1) {
-		log.Printf("running: %q / %#v", query, args)
+		flog.Infof("running: %q / %#v", query, args)
 	}
 
 	q = q.Literal("LIMIT 100")
@@ -564,7 +564,7 @@ func (v VendorDataTrimmer) selectVersions(ctx context.Context, q *sqlutil.Select
 	query, args := q.String(), q.QueryArgs()
 
 	if debug.V(1) {
-		log.Printf("running: %q / %#v", query, args)
+		flog.Infof("running: %q / %#v", query, args)
 	}
 
 	rows, err := v.DB.QueryContext(ctx, query, args...)


### PR DESCRIPTION
There were a few places that still used calles with the log package. Replacing with flog to use GLOG everywhere