### PR TITLE
[cvss] Introduce an AbsorbIfDefined() function

### DIFF
--- a/cvss2/vector.go
+++ b/cvss2/vector.go
@@ -96,6 +96,18 @@ func (v *Vector) Absorb(other Vector) {
 	}
 }
 
+// AbsorbIfDefined is like Absorb but will not override vector components that
+// are not present in v.
+func (v *Vector) AbsorbIfDefined(other Vector) {
+	parseables := v.parseables()
+	old := v.definables()
+	for metric, defineable := range other.definables() {
+		if old[metric].defined() && defineable.defined() {
+			parseables[metric].parse(defineable.String())
+		}
+	}
+}
+
 // helpers
 
 var order = []string{"AV", "AC", "Au", "C", "I", "A", "E", "RL", "RC", "CDP", "TD", "CR", "IR", "AR", "ME", "MRL", "MRC"}

--- a/cvss3/vector.go
+++ b/cvss3/vector.go
@@ -128,6 +128,18 @@ func (v *Vector) Absorb(other Vector) {
 	}
 }
 
+// AbsorbIfDefined is like Absorb but will not override vector components that
+// are not present in v.
+func (v *Vector) AbsorbIfDefined(other Vector) {
+	parseables := v.parseables()
+	old := v.definables()
+	for metric, defineable := range other.definables() {
+		if old[metric].defined() && defineable.defined() {
+			parseables[metric].parse(defineable.String())
+		}
+	}
+}
+
 // helpers
 
 var order = []string{"AV", "AC", "PR", "UI", "S", "C", "I", "A", "E", "RL", "RC", "CR", "IR", "AR", "MAV", "MAC", "MPR", "MUI", "MS", "MC", "MI", "MA", "ME", "MRL", "MRC"}


### PR DESCRIPTION
Absorb semantics mean that, if the component is not defined in v1 but is in
v2, it will appear in the final result.

In some cases, it can be useful to only absorb vector components that are
defined in v1. AbsordIfDefined does just that.