### PR TITLE
[cvss] Add functions to compare two CVSS vectors

### DIFF
--- a/cvss2/vector.go
+++ b/cvss2/vector.go
@@ -33,6 +33,52 @@ type Vector struct {
 	EnvironmentalMetrics
 }
 
+// For some metrics, "not defined" is equivalent to specifying another value. eg.
+// E:X is equivalent to E:H.
+var undefinedEquivalent = map[string]string{
+	// Temporal metrics
+	"E":  "H",
+	"RL": "U",
+	"RC": "C",
+	// Environmental metrics
+	"CDP": "N",
+	"TD":  "H",
+	"CR":  "M",
+	"IR":  "M",
+	"AR":  "M",
+}
+
+func equivalent(metric, value string) string {
+	if value != "ND" {
+		return value
+	}
+	e, ok := undefinedEquivalent[metric]
+	if !ok {
+		return value
+	}
+	return e
+}
+
+// Equal returns true if o represents the same vector as v.
+//
+// Note that the definition of equal here means that two vectors with different
+// string representations can still be equal. For instance TD:ND is defined as
+// the same as TD:H.
+func (v Vector) Equal(o Vector) bool {
+	vDefs := v.definables()
+	oDefs := o.definables()
+
+	for _, metric := range order {
+		a := equivalent(metric, vDefs[metric].String())
+		b := equivalent(metric, oDefs[metric].String())
+
+		if a != b {
+			return false
+		}
+	}
+	return true
+}
+
 // String returns this vectors representation as a string
 // it shouldn't depend on the order of metrics
 func (v Vector) String() string {

--- a/cvss2/vector_test.go
+++ b/cvss2/vector_test.go
@@ -70,6 +70,38 @@ func BenchmarkParse(b *testing.B) {
 	}
 }
 
+func TestEqual(t *testing.T) {
+	for i, c := range []struct {
+		v1, v2   string
+		expected bool
+	}{
+		// Same vectors.
+		{"(AV:N/AC:M/Au:S/C:P/I:N/A:N)", "(AV:N/AC:M/Au:S/C:P/I:N/A:N)", true},
+		// Different vectors.
+		{"(AV:N/AC:H/Au:S/C:P/I:N/A:N)", "(AV:N/AC:M/Au:S/C:P/I:N/A:N)", false},
+		// For some metrics, ND (not defined) is the same as specifying another value.
+		{"(E:ND)", "(E:H)", true},
+		{"(E:F)", "(E:H)", false},
+		{"(AC:L)", "(AC:L/E:H)", true},
+		{"(RL:ND)", "(RL:U)", true},
+		{"(RC:ND)", "(RC:C)", true},
+		{"(CDP:ND)", "(CDP:N)", true},
+		{"(TD:ND)", "(TD:H)", true},
+		{"(CR:ND)", "(CR:M)", true},
+		{"(IR:ND)", "(IR:M)", true},
+		{"(AR:ND)", "(AR:M)", true},
+	} {
+		t.Run(fmt.Sprintf("case %2d", i+1), func(t *testing.T) {
+			v1, err := VectorFromString(c.v1)
+			assert.NoError(t, err)
+			v2, err := VectorFromString(c.v2)
+			assert.NoError(t, err)
+
+			assert.Equal(t, c.expected, v1.Equal(v2))
+		})
+	}
+}
+
 func TestAbsorb(t *testing.T) {
 	for i, c := range []struct {
 		v1, v2, expected string


### PR DESCRIPTION
To compare for equility, we want to do a bit more than just comparing the
string representations of vectors. For some of the metrics, not specifying a
score is the same as specifying one of the other possible values.

For instance Remediation Level (RL):

> Assigning this value indicates there is insufficient information to choose
> one of the other values, and has no impact on the overall Temporal Score,
> i.e., it has the same effect on scoring as assigning Unavailable.

So not specifying RL or setting RL:X is the same as setting RL:U.