### PR TITLE
Added String method to convert rpm.Package structs to string form

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,6 +56,6 @@ jobs:
         with:
           # The version of golangci-lint is required and must be specified
           # without patch version: we always use the latest patch version.
-          version: v1.28
+          version: v1.45
           working-directory: ${{ github.repository }}
           args: "--disable-all -E golint -E gosimple -E govet -E ineffassign -E staticcheck -E structcheck -E varcheck -e SA5011:"

--- a/rpm/parse.go
+++ b/rpm/parse.go
@@ -33,6 +33,10 @@ type Label struct {
 	Release string
 }
 
+func (p *Package) String() string {
+	return fmt.Sprintf("%s-%s:%s-%s.%s", p.Name, p.Epoch, p.Version, p.Release, p.Arch)
+}
+
 // Parse returns name, version, release and architecture parsed from RPM package name
 // NEVRA: https://blog.jasonantman.com/2014/07/how-yum-and-rpm-compare-versions/
 func Parse(pkg string) (*Package, error) {


### PR DESCRIPTION
This way, we can switch back and forth from string represtation to struct using String/Parse. Useful in case you want to serialise the struct or represent it in a human-readable way

Tried to do the conversion back and forth and obtained the same rpm.Package struct as a result

```
{Name:cups Label:{Epoch:1 Version:1.6.3 Release:51.el7} Arch:}
```