### PR TITLE
Fix linter.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,4 +58,4 @@ jobs:
           # without patch version: we always use the latest patch version.
           version: v1.45
           working-directory: ${{ github.repository }}
-          args: "--disable-all -E golint -E gosimple -E govet -E ineffassign -E staticcheck -E structcheck -E varcheck -e SA5011:"
+          args: "--disable-all -E revive -E gosimple -E govet -E ineffassign -E staticcheck -E structcheck -E varcheck -e SA5011: -e SA1019:"

--- a/cvefeed/cvecache.go
+++ b/cvefeed/cvecache.go
@@ -70,10 +70,10 @@ type cachedCVEs struct {
 
 // updateResSize calculates the size of cached MatchResult and assigns it to cves.size
 func (cves *cachedCVEs) updateResSize(key string) {
-	cves.size = int64(int(unsafe.Sizeof(key)) + len(key))
 	if cves == nil {
 		return
 	}
+	cves.size = int64(int(unsafe.Sizeof(key)) + len(key))
 	cves.size += int64(unsafe.Sizeof(cves.res))
 	for i := range cves.res {
 		cves.size += int64(unsafe.Sizeof(cves.res[i].CVE))

--- a/providers/redhat/package_feed_test.go
+++ b/providers/redhat/package_feed_test.go
@@ -26,7 +26,7 @@ import (
 type summary map[string][]string
 
 func feedSummary(feed packageFeed) summary {
-	var s summary = make(summary)
+	s := make(summary)
 	for pkg, cves := range feed {
 		var cveNames []string
 		for _, cve := range cves {

--- a/rpm/parse.go
+++ b/rpm/parse.go
@@ -43,9 +43,7 @@ func Parse(pkg string) (*Package, error) {
 	// pkg should be name-[epoch:]version-release.arch.rpm
 
 	// extension
-	if strings.HasSuffix(pkg, ".rpm") {
-		pkg = pkg[:len(pkg)-4]
-	}
+	pkg = strings.TrimSuffix(pkg, ".rpm")
 
 	var p Package
 


### PR DESCRIPTION
What's done:
  * change linter from deprecated golint to revive
  * exclude SA5011 (deprecated strings.Title() call) -- the string
    passed to it is guaranteed to be ASCII
  * move nil-pointer check before first pointer dereferece in
    cvefeed/cvecache.go
  * proper declare-initialze syntax in
    providers/redhat/package_feed_test.go:feedSummary()
  * replace if strings.HasSuffix(..) { // manually trim suffix } with
    strings.TrimSuffix() in rpm/parse.go