### PR TITLE
Providers: use the new snyk API

### DIFF
--- a/cmd/snyk2nvd/snyk2nvd.go
+++ b/cmd/snyk2nvd/snyk2nvd.go
@@ -66,7 +66,7 @@ func main() {
 	flag.Var(&lf, "language", "Comma separated list of languages to download/convert. If not set, then use all available")
 	r := runner.Runner{
 		Config: runner.Config{
-			BaseURL: "https://data.snyk.io/api/v4",
+			BaseURL: "https://api.snyk.io/rest/orgs",
 			ClientConfig: client.Config{
 				UserAgent: "snyk2nvd",
 			},
@@ -110,7 +110,7 @@ func (lf *languageFilter) Set(val string) error {
 }
 
 func (lf *languageFilter) accepts(adv *schema.Advisory) bool {
-	return lf == nil || len(*lf) == 0 || (*lf)[adv.Language]
+	return lf == nil || len(*lf) == 0 || (*lf)[adv.Ecosystem]
 }
 
 func (lf *languageFilter) filter(ch <-chan *schema.Advisory) <-chan runner.Convertible {

--- a/providers/snyk/schema/convert.go
+++ b/providers/snyk/schema/convert.go
@@ -49,13 +49,13 @@ func (advisory *Advisory) Convert() (*nvd.NVDCVEFeedJSON10DefCVEItem, error) {
 		Impact: &nvd.NVDCVEFeedJSON10DefImpact{
 			BaseMetricV3: &nvd.NVDCVEFeedJSON10DefImpactBaseMetricV3{
 				CVSSV3: &nvd.CVSSV30{
-					VectorString: advisory.CVSSV3,
-					BaseScore:    advisory.CvssScore,
+					VectorString: advisory.CVSSV3Vector,
+					BaseScore:    advisory.CVSSV3BaseScore,
 				},
 			},
 		},
-		LastModifiedDate: snykTimeToNVD(advisory.ModificationTime),
-		PublishedDate:    snykTimeToNVD(advisory.PublicationTime),
+		LastModifiedDate: snykTimeToNVD(advisory.Modified),
+		PublishedDate:    snykTimeToNVD(advisory.Published),
 	}
 
 	return &nvdItem, nil
@@ -66,17 +66,17 @@ func (advisory *Advisory) ID() string {
 }
 
 func (advisory *Advisory) newProblemType() *nvd.CVEJSON40Problemtype {
-	if len(advisory.Cwes) == 0 {
+	if len(advisory.CweIDs) == 0 {
 		return nil
 	}
 	pt := &nvd.CVEJSON40Problemtype{
 		ProblemtypeData: []*nvd.CVEJSON40ProblemtypeProblemtypeData{
 			{
-				Description: make([]*nvd.CVEJSON40LangString, len(advisory.Cwes)),
+				Description: make([]*nvd.CVEJSON40LangString, len(advisory.CweIDs)),
 			},
 		},
 	}
-	for i, cwe := range advisory.Cwes {
+	for i, cwe := range advisory.CweIDs {
 		pt.ProblemtypeData[0].Description[i] = &nvd.CVEJSON40LangString{
 			Lang:  "en",
 			Value: cwe,
@@ -89,7 +89,7 @@ func (advisory *Advisory) newReferences() *nvd.CVEJSON40References {
 	if len(advisory.References) == 0 {
 		return nil
 	}
-	nrefs := 1 + len(advisory.References) + len(advisory.Cves)
+	nrefs := 1 + len(advisory.References) + len(advisory.CveIDs)
 	refs := &nvd.CVEJSON40References{
 		ReferenceData: make([]*nvd.CVEJSON40Reference, 0, nrefs),
 	}
@@ -99,13 +99,13 @@ func (advisory *Advisory) newReferences() *nvd.CVEJSON40References {
 			URL:  url,
 		})
 	}
-	if advisory.Title != "" && advisory.URL != "" {
-		addRef(advisory.Title, advisory.URL)
+	if advisory.Title != "" && advisory.SnykAdvisoryURL != "" {
+		addRef(advisory.Title, advisory.SnykAdvisoryURL)
 	}
 	for _, ref := range advisory.References {
 		addRef(ref.Title, ref.URL)
 	}
-	for _, cve := range advisory.Cves {
+	for _, cve := range advisory.CveIDs {
 		addRef(cve, "")
 	}
 	return refs

--- a/providers/snyk/schema/schema.go
+++ b/providers/snyk/schema/schema.go
@@ -14,36 +14,69 @@
 
 package schema
 
-// language -> [advisories]
-type Advisories map[string][]*Advisory
-
 type Advisory struct {
-	CVSSV3             string       `json:"cvssV3"`
-	CreationTime       string       `json:"creationTime"`
-	Credit             []string     `json:"credit"`
-	Cves               []string     `json:"cves"`
-	CvssScore          float64      `json:"cvssScore"`
-	Cwes               []string     `json:"cwes"`
-	Description        string       `json:"description"`
-	DisclosureTime     string       `json:"disclosureTime"`
-	Exploit            string       `json:"exploit"`
-	Fixable            bool         `json:"fixable"`
-	HashesRange        []string     `json:"hashesRange,omitempty"`
-	SnykID             string       `json:"id"`
-	Language           string       `json:"language"`
-	ModificationTime   string       `json:"modificationTime"`
-	Package            string       `json:"package"`
-	PatchExists        bool         `json:"patchExists"`
-	PublicationTime    string       `json:"publicationTime"`
-	References         []*Reference `json:"references"`
-	Severity           string       `json:"severity"`
-	Title              string       `json:"title"`
-	URL                string       `json:"url"`
-	VulnerableHashes   []string     `json:"vulnerableHashes,omitempty"`
-	VulnerableVersions []string     `json:"vulnerableVersions"`
+	Credits                  []string               `json:"credits"`
+	CveIDs                   []string               `json:"cve_ids"`
+	CVSSDetails              []*CVSSDetails         `json:"cvss_details"`
+	CVSSV3BaseScore          float64                `json:"cvss_v3_base_score"`
+	CVSSV3Vector             string                 `json:"cvss_v3_vector"`
+	CweIDs                   []string               `json:"cwe_ids"`
+	Description              string                 `json:"description"`
+	DescriptionOverview      string                 `json:"description_overview"`
+	DescriptionRemediation   string                 `json:"description_remediation"`
+	Disclosed                string                 `json:"disclosed"`
+	Ecosystem                string                 `json:"ecosystem"`
+	ExploitCodeMaturity      string                 `json:"exploit_code_maturity"`
+	InitiallyFixedInVersions []string               `json:"initially_fixed_in_versions"`
+	IsFixable                bool                   `json:"is_fixable"`
+	IsMalicious              bool                   `json:"is_malicious"`
+	IsSocialMediaTrending    bool                   `json:"is_social_media_trending"`
+	Modified                 string                 `json:"modified"`
+	Package                  string                 `json:"package"`
+	PackageRepositoryURL     string                 `json:"package_repository_url"`
+	Published                string                 `json:"published"`
+	References               []*Reference           `json:"references"`
+	Severity                 string                 `json:"severity"`
+	SnykAdvisoryURL          string                 `json:"snyk_advisory_url"`
+	SnykID                   string                 `json:"snyk_id"`
+	Title                    string                 `json:"title"`
+	VulnerableFunctions      []*VulnerableFunctions `json:"vulnerable_functions"`
+	VulnerableHashRanges     []string               `json:"vulnerable_hash_ranges,omitempty"`
+	VulnerableHashes         []string               `json:"vulnerable_hashes,omitempty"`
+	VulnerableVersions       []string               `json:"vulnerable_versions"`
+}
+
+type VulnerableFunctions struct {
+	FunctionID struct {
+		ClassName    string `json:"class_name"`
+		FilePath     string `json:"file_path"`
+		FunctionName string `json:"function_name"`
+	} `json:"function_id"`
+	Version []string `json:"version"`
+}
+
+type CVSSDetails struct {
+	Assigner        string  `json:"assigner"`
+	CVSSV3Vector    string  `json:"cvss_v3_vector"`
+	CVSSV3BaseScore float64 `json:"cvss_v3_base_score"`
+	Severity        string  `json:"severity"`
+	Modified        string  `json:"modified"`
 }
 
 type Reference struct {
 	Title string `json:"title"`
 	URL   string `json:"url"`
+}
+
+type RestAPI struct {
+	JsonAPI struct {
+		Version string `json:"version"`
+	} `json:jsonapi`
+	Data struct {
+		Type string `json:"type"`
+		URL  string `json:"url"`
+	} `json:data`
+	Links struct {
+		Self string `json:"self"`
+	} `json:"links"`
 }


### PR DESCRIPTION
Snyk is shutting down its API soon and we must migrate to a new one. Major changes include:
  - New authentication method;
  - Data is compressed with gzip;
  - Data is in the nd-json format;
  - New schema for the data (similar to the old one).