### PR TITLE
Snyk gzip encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ TOOLS = \
 	nvdsync \
 	rpm2cpe \
 	rustsec2nvd \
+	snyk2nvd \
 	vulndb
 
 DOCS = \

--- a/providers/snyk/api/client.go
+++ b/providers/snyk/api/client.go
@@ -15,7 +15,6 @@
 package api
 
 import (
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -51,16 +50,11 @@ func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-ch
 		return nil, fmt.Errorf("can't get vulnerabilities: %v", err)
 	}
 
-	gzipRdr, err := gzip.NewReader(content)
-	if err != nil {
-		return nil, fmt.Errorf("can't decode gzip data: %v", err)
-	}
-	jsonRdr := json.NewDecoder(gzipRdr)
+	jsonRdr := json.NewDecoder(content)
 
 	output := make(chan *schema.Advisory)
 	go func() {
 		defer close(output)
-		defer gzipRdr.Close()
 		defer content.Close()
 		for {
 			var advisory schema.Advisory


### PR DESCRIPTION
As detailed in the commits individually, the upstream API started to return replies unencoded, so it needs to be fixed