### PR TITLE
Fix linter.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,6 +56,6 @@ jobs:
         with:
           # The version of golangci-lint is required and must be specified
           # without patch version: we always use the latest patch version.
-          version: v1.45
+          version: v1.50
           working-directory: ${{ github.repository }}
           args: "--disable-all -E revive -E gosimple -E govet -E ineffassign -E staticcheck -E structcheck -E varcheck -e SA5011: -e SA1019:"

--- a/providers/snyk/api/client.go
+++ b/providers/snyk/api/client.go
@@ -84,10 +84,13 @@ func (c *Client) get(ctx context.Context, feed string) (io.ReadCloser, error) {
 		"Accept":        {"application/vnd.api+json"},
 		"Authorization": {"Token " + c.secret},
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get vulnerabilities at %q: %v", url, err)
+	}
 	defer resp.Body.Close()
 	var jsonResp schema.RestAPI
 	if err := json.NewDecoder(resp.Body).Decode(&jsonResp); err != nil {
-		return nil, fmt.Errorf("failed to get vulnerabilities at %q: %v", url, err)
+		return nil, fmt.Errorf("failed to decode vulnerabilities: %v", err)
 	}
 
 	url = jsonResp.Data.URL

--- a/providers/snyk/schema/schema.go
+++ b/providers/snyk/schema/schema.go
@@ -69,13 +69,13 @@ type Reference struct {
 }
 
 type RestAPI struct {
-	JsonAPI struct {
+	JSONAPI struct {
 		Version string `json:"version"`
-	} `json:jsonapi`
+	} `json:"jsonapi"`
 	Data struct {
 		Type string `json:"type"`
 		URL  string `json:"url"`
-	} `json:data`
+	} `json:"data"`
 	Links struct {
 		Self string `json:"self"`
 	} `json:"links"`


### PR DESCRIPTION
Bad JSON tags in providers/snyk/schema/schema.go, JsonAPI should be JSONAPI, ther was an assignment to unused var (unchecked `err`) in providers/snyk/api/client.go.