### PR TITLE
[vulndb] Checking for errors after scanning all rows

### DIFF
--- a/vulndb/export.go
+++ b/vulndb/export.go
@@ -240,6 +240,10 @@ func (exp DataExporter) JSON(ctx context.Context, w io.Writer, indent string) er
 		}
 	}
 
+	if rows.Err() != nil {
+		return errors.Wrap(err, "unable to read all rows from result set")
+	}
+
 	if indent == "" {
 		return f.EncodeJSON(w)
 	}


### PR DESCRIPTION
From https://pkg.go.dev/database/sql#Rows.Next:
```
Next prepares the next result row for reading with the Scan method. It returns true on success, or false if there is no next result row or an error happened while preparing it. Err should be consulted to distinguish between the two cases.
```

Due to not checking this, a user might hit timeout issues and believe that they had the complete resultset. This diffs returns an error in this case