### PR TITLE
Fixing incorrect error variable returned

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,6 +56,6 @@ jobs:
         with:
           # The version of golangci-lint is required and must be specified
           # without patch version: we always use the latest patch version.
-          version: v1.50
+          version: v1.52
           working-directory: ${{ github.repository }}
           args: "--disable-all -E revive -E gosimple -E govet -E ineffassign -E staticcheck -E structcheck -E varcheck -e SA5011: -e SA1019:"

--- a/cmd/rbs2nvd/rbs2nvd.go
+++ b/cmd/rbs2nvd/rbs2nvd.go
@@ -48,7 +48,7 @@ func Read(r io.Reader, c chan runner.Convertible) error {
 	return nil
 }
 
-func FetchSince(ctx context.Context, c client.Client, baseURL string, since int64) (<-chan runner.Convertible, error) {
+func FetchSince(_ context.Context, c client.Client, baseURL string, since int64) (<-chan runner.Convertible, error) {
 	clientID := os.Getenv("RBS_CLIENT_ID")
 	if clientID == "" {
 		return nil, fmt.Errorf("please set RBS_CLIENT_ID in environment")

--- a/cmd/redhat_filter/main_test.go
+++ b/cmd/redhat_filter/main_test.go
@@ -98,6 +98,6 @@ func TestFilter(t *testing.T) {
 // fixed packages are the ones with this name
 type testChecker string
 
-func (name testChecker) Check(pkg *rpm.Package, distro *wfn.Attributes, cve string) bool {
+func (name testChecker) Check(pkg *rpm.Package, _ *wfn.Attributes, _ string) bool {
 	return pkg.Name == string(name)
 }

--- a/cmd/redhat_query/fetch-cve.go
+++ b/cmd/redhat_query/fetch-cve.go
@@ -36,7 +36,7 @@ func init() {
 	rootCmd.AddCommand(fetchCVECmd)
 }
 
-func fetchCVE(cmd *cobra.Command, args []string) error {
+func fetchCVE(_ *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return errors.New("fetch-cve: missing CVE name")
 	}

--- a/cmd/redhat_query/fixed-cves.go
+++ b/cmd/redhat_query/fixed-cves.go
@@ -36,7 +36,7 @@ func init() {
 	rootCmd.AddCommand(fixedCVEsCmd)
 }
 
-func fixedCVEs(cmd *cobra.Command, args []string) error {
+func fixedCVEs(_ *cobra.Command, args []string) error {
 	if len(args) == 0 {
 		return errors.New("fixed-cves: missing package name(s)")
 	}

--- a/providers/idefense/schema/convert.go
+++ b/providers/idefense/schema/convert.go
@@ -147,9 +147,7 @@ func (item *Vulnerability) makeConfigurations() (*nvd.NVDCVEFeedJSON10DefConfigu
 					match.VersionEndExcluding = cfg.FixedByVersion
 				}
 			} else {
-				if affected.Prior {
-					// affects all versions
-				} else {
+				if !affected.Prior {
 					match.VersionStartIncluding = affected.Version
 				}
 			}

--- a/providers/nvd/cpe_test.go
+++ b/providers/nvd/cpe_test.go
@@ -55,7 +55,7 @@ func TestCPE(t *testing.T) {
 
 type cpeTestServer struct{}
 
-func (ts cpeTestServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (ts cpeTestServer) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Etag", "foobar")
 	fmt.Fprintf(w, "hello, world")
 }

--- a/providers/nvd/src.go
+++ b/providers/nvd/src.go
@@ -52,7 +52,7 @@ func NewSourceConfig() *SourceConfig {
 }
 
 // AddFlags adds SourceConfig flags to the given FlagSet.
-func (src *SourceConfig) AddFlags(fs *flag.FlagSet) {
+func (src *SourceConfig) AddFlags(_ *flag.FlagSet) {
 	flag.StringVar(&src.Scheme, "src_scheme", src.Scheme, "source scheme\nenv: NVDSYNC_SCHEME")
 	flag.StringVar(&src.Host, "src_host", src.Host, "source host\nenv: NVDSYNC_HOST")
 	flag.StringVar(&src.CVEFeedPath, "src_cve_feed_path", src.CVEFeedPath, "source path for CVE feeds\nenv: NVDSYNC_CVE_FEED_PATH")

--- a/providers/nvd/xrename.go
+++ b/providers/nvd/xrename.go
@@ -26,23 +26,23 @@ import (
 func xRename(oldpath, newpath string) error {
 	err := os.Rename(oldpath, newpath)
 	if _, ok := err.(*os.LinkError); ok {
-		var old, new *os.File
-		if old, err = os.Open(oldpath); err != nil {
+		var oldfile, newfile *os.File
+		if oldfile, err = os.Open(oldpath); err != nil {
 			return err
 		}
-		defer old.Close()
+		defer oldfile.Close()
 		var finfo os.FileInfo
-		if finfo, err = old.Stat(); err != nil {
+		if finfo, err = oldfile.Stat(); err != nil {
 			return err
 		}
 		if !finfo.Mode().IsRegular() {
 			return fmt.Errorf("failed to rename %q to %q: source file is not a regular file", oldpath, newpath)
 		}
-		if new, err = os.OpenFile(newpath, os.O_WRONLY|os.O_CREATE, finfo.Mode().Perm()); err != nil {
+		if newfile, err = os.OpenFile(newpath, os.O_WRONLY|os.O_CREATE, finfo.Mode().Perm()); err != nil {
 			return err
 		}
-		defer new.Close()
-		if _, err = io.Copy(new, old); err != nil {
+		defer newfile.Close()
+		if _, err = io.Copy(newfile, oldfile); err != nil {
 			return err
 		}
 		err = os.Remove(oldpath)

--- a/providers/redhat/check/check_pkg.go
+++ b/providers/redhat/check/check_pkg.go
@@ -60,7 +60,7 @@ type singleChecker struct {
 	pkgChecker pkgCheck
 }
 
-func (c *singleChecker) Check(pkg *rpm.Package, distro *wfn.Attributes, cve string) bool {
+func (c *singleChecker) Check(pkg *rpm.Package, distro *wfn.Attributes, _ string) bool {
 	if pkg == nil {
 		// just a sanity check, shouldn't even be called with nil
 		return false

--- a/providers/snyk/api/client.go
+++ b/providers/snyk/api/client.go
@@ -44,7 +44,7 @@ func NewClient(c client.Client, baseURL, consumerID, secret string) *Client {
 	}
 }
 
-func (c *Client) FetchAllVulnerabilities(ctx context.Context, since int64) (<-chan *schema.Advisory, error) {
+func (c *Client) FetchAllVulnerabilities(ctx context.Context, _ int64) (<-chan *schema.Advisory, error) {
 	// since is ignored, always download all from snyk
 	content, err := c.get(ctx, "application_premium")
 	if err != nil {

--- a/providers/vfeed/api/client.go
+++ b/providers/vfeed/api/client.go
@@ -41,7 +41,7 @@ func NewClient(path string) *Client {
 
 // FetchAllVulnerabilities will return all vfeed items. The "since" parameter is
 // ignored.
-func (c *Client) FetchAllVulnerabilities(since int64) (<-chan *schema.Item, error) {
+func (c *Client) FetchAllVulnerabilities(_ int64) (<-chan *schema.Item, error) {
 	items := make(chan *schema.Item)
 
 	matches, err := filepath.Glob(c.path + suffixPattern)

--- a/providers/vfeed/schema/convert_test.go
+++ b/providers/vfeed/schema/convert_test.go
@@ -59,11 +59,7 @@ func unmarshalFile(item interface{}, name string) error {
 		return err
 	}
 
-	if err := json.Unmarshal(data, item); err != nil {
-		return err
-	}
-
-	return nil
+	return json.Unmarshal(data, item)
 }
 
 func mustMarshal(item interface{}) string {

--- a/rpm/checker_test.go
+++ b/rpm/checker_test.go
@@ -111,7 +111,8 @@ func isAllOnes(n int) bool {
 	if n == 0 {
 		return false
 	}
-	for ; n&1 == 1; n >>= 1 {
+	for n&1 == 1 {
+		n >>= 1
 	}
 	return n == 0
 }

--- a/rpm/compare.go
+++ b/rpm/compare.go
@@ -171,7 +171,8 @@ func isZero(r rune) bool {
 
 func takeWhile(s string, f func(rune) bool) (matched, rest string) {
 	var i int
-	for i = 0; i < len(s) && f(rune(s[i])); i++ {
+	for i < len(s) && f(rune(s[i])) {
+		i++
 	}
 	return s[:i], s[i:]
 }

--- a/vulndb/export.go
+++ b/vulndb/export.go
@@ -186,6 +186,10 @@ func (exp DataExporter) CSV(ctx context.Context, w io.Writer, header bool) error
 		})
 	}
 
+	if rows.Err() != nil {
+		return errors.Wrap(rows.Err(), "unable to read all rows from result set")
+	}
+
 	return nil
 }
 
@@ -241,7 +245,7 @@ func (exp DataExporter) JSON(ctx context.Context, w io.Writer, indent string) er
 	}
 
 	if rows.Err() != nil {
-		return errors.Wrap(err, "unable to read all rows from result set")
+		return errors.Wrap(rows.Err(), "unable to read all rows from result set")
 	}
 
 	if indent == "" {

--- a/vulndb/export.go
+++ b/vulndb/export.go
@@ -186,11 +186,7 @@ func (exp DataExporter) CSV(ctx context.Context, w io.Writer, header bool) error
 		})
 	}
 
-	if rows.Err() != nil {
-		return errors.Wrap(rows.Err(), "unable to read all rows from result set")
-	}
-
-	return nil
+	return errors.Wrap(rows.Err(), "unable to read all rows from result set")
 }
 
 // JSON exports NVD CVE JSON to w.


### PR DESCRIPTION
When the rows object stops yielding rows and returns an error through the `Err()` method, it would then use `err` instead of `rows.Err()`, which at that point is nil, causing these errors to not be reported downstream.

Also, added this same check in the CSV export method