### PR TITLE
fix: cpe match na version

### DIFF
--- a/cvefeed/nvd/match_cpe.go
+++ b/cvefeed/nvd/match_cpe.go
@@ -114,6 +114,11 @@ func (cm *cpeMatch) match(attr *wfn.Attributes, requireVersion bool) bool {
 		return false
 	}
 
+	// if hasVersionRanges and attr version is NA, then return false
+	if attr.Version == wfn.NA {
+		return false
+	}
+
 	// match version to ranges
 	ver := wfn.StripSlashes(attr.Version)
 


### PR DESCRIPTION
CVE-2019-19844

cpe: `cpe:2.3:a:djangoproject:django:-`

matchs:

```json
[
    {
        "children": [],
        "operator": "OR",
        "cpe_match": [
            {
                "cpe23Uri": "cpe:2.3:a:djangoproject:django:*:*:*:*:*:*:*:*",
                "cpe_name": [],
                "vulnerable": true,
                "versionEndExcluding": "2.2.9",
                "versionStartIncluding": "2.2"
            },
            {
                "cpe23Uri": "cpe:2.3:a:djangoproject:django:3.0:*:*:*:*:*:*:*",
                "cpe_name": [],
                "vulnerable": true
            },
            {
                "cpe23Uri": "cpe:2.3:a:djangoproject:django:*:*:*:*:*:*:*:*",
                "cpe_name": [],
                "vulnerable": true,
                "versionEndExcluding": "1.11.27"
            }
        ]
    },
    {
        "children": [],
        "operator": "OR",
        "cpe_match": [
            {
                "cpe23Uri": "cpe:2.3:o:canonical:ubuntu_linux:16.04:*:*:*:lts:*:*:*",
                "cpe_name": [],
                "vulnerable": true
            },
            {
                "cpe23Uri": "cpe:2.3:o:canonical:ubuntu_linux:18.04:*:*:*:lts:*:*:*",
                "cpe_name": [],
                "vulnerable": true
            },
            {
                "cpe23Uri": "cpe:2.3:o:canonical:ubuntu_linux:19.04:*:*:*:*:*:*:*",
                "cpe_name": [],
                "vulnerable": true
            },
            {
                "cpe23Uri": "cpe:2.3:o:canonical:ubuntu_linux:19.10:*:*:*:*:*:*:*",
                "cpe_name": [],
                "vulnerable": true
            }
        ]
    }
]
```
this rule will match, before fix.
```json
            {
                "cpe23Uri": "cpe:2.3:a:djangoproject:django:*:*:*:*:*:*:*:*",
                "cpe_name": [],
                "vulnerable": true,
                "versionEndExcluding": "1.11.27"
            }
```

