### PR TITLE
Fix: wrong cpe version match

### DIFF
--- a/cvefeed/nvd/smartvercmp.go
+++ b/cvefeed/nvd/smartvercmp.go
@@ -96,3 +96,4 @@ func lpad(s string, n int) string {
 	sb.WriteString(s)
 	return sb.String()
 }
+

--- a/cvefeed/nvd/version.go
+++ b/cvefeed/nvd/version.go
@@ -1,0 +1,86 @@
+package nvd
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type ComponentVersion struct {
+	VersionParts []string
+}
+
+var versionPattern = regexp.MustCompile(`(\d+[a-z]{1,3}$|[a-z]{1,3}[_-]?\d+|\d+|(rc|release|snapshot|beta|alpha)$)`)
+
+func ParseVersion(version string) *ComponentVersion {
+	versionParts := make([]string, 0)
+	if version == "" {
+		return nil
+	}
+
+	lcVersion := strings.ToLower(version)
+	versionSubmatch := versionPattern.FindAllStringSubmatch(lcVersion, -1)
+	for _, vs := range versionSubmatch {
+		versionParts = append(versionParts, vs...)
+	}
+	if len(versionParts) == 0 {
+		versionParts = append(versionParts, version)
+	}
+
+	return &ComponentVersion{
+		VersionParts: versionParts,
+	}
+}
+
+func (cv *ComponentVersion) CompareTo(v *ComponentVersion) int {
+	if v == nil {
+		return 1
+	}
+	left := cv.VersionParts
+	right := v.VersionParts
+
+	var max int
+	if len(left) < len(right) {
+		max = len(left)
+	} else {
+		max = len(right)
+	}
+	for i := 0; i < max; i++ {
+		lStr := left[i]
+		rStr := right[i]
+		if lStr == rStr {
+			continue
+		}
+		l, lerr := strconv.Atoi(lStr)
+		r, rerr := strconv.Atoi(rStr)
+		if lerr != nil || rerr != nil {
+			comp := strings.Compare(lStr, rStr)
+			if comp < 0 {
+				return -1
+			} else if comp > 0 {
+				return 1
+			}
+		}
+		if l < r {
+			return -1
+		} else if l > r {
+			return 1
+		}
+	}
+	if len(left) == max && len(right) == len(left) + 1 && right[len(right) - 1] == "0" {
+		return 0
+	} else if len(right) == max && len(left) == len(right) + 1 && left[len(left) - 1] == "0" {
+		return 0
+	} else {
+		if len(left) > len(right) {
+			return 1
+		}
+		if len(right) > len(left) {
+			return -1
+		}
+		if len(right) == len(left) {
+			return 0
+		}
+	}
+	return 0
+}

--- a/cvefeed/nvd/version_test.go
+++ b/cvefeed/nvd/version_test.go
@@ -1,0 +1,59 @@
+package nvd
+
+import "testing"
+
+func TestComponentVersion_CompareTo(t *testing.T) {
+	type fields struct {
+		VersionParts []string
+	}
+	type args struct {
+		v *ComponentVersion
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   int
+	}{
+		{
+			name: "test-version-compare",
+			fields: fields{
+				VersionParts: ParseVersion("2.6.3").VersionParts,
+			},
+			args: args{
+				v: ParseVersion("2.6.4"),
+			},
+			want: -1,
+		},
+		{
+			name: "test-version-compare",
+			fields: fields{
+				VersionParts: ParseVersion("7.0.0").VersionParts,
+			},
+			args: args{
+				v: ParseVersion("7.0.0."),
+			},
+			want: 0,
+		},
+		{
+			name: "test-version-compare",
+			fields: fields{
+				VersionParts: ParseVersion("x.y.z").VersionParts,
+			},
+			args: args{
+				v: ParseVersion("7.0.0"),
+			},
+			want: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cv := &ComponentVersion{
+				VersionParts: tt.fields.VersionParts,
+			}
+			if got := cv.CompareTo(tt.args.v); got != tt.want {
+				t.Errorf("ComponentVersion.CompareTo() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/wfn/wfn.go
+++ b/wfn/wfn.go
@@ -29,7 +29,7 @@ var KnownParts = map[string]string{
 // Possible logical value of Attributes
 // empty string considered ANY when parsing and unquoted "-" is illegal in WFN attribute-value
 const (
-	Any = ""
+	Any = "*"
 	NA  = "-"
 )
 


### PR DESCRIPTION
We came across a scene like this
 
the cpe is like: cpe:/a:xxx:yyy:x.y.z, but the version should always start with a number, so it should not match any cve. But after padding 0 to left, the version is became to 0x.y.z, so with go's strings.compare, it will match any cpe version which starts with 0 and has versionendincluding
![image](https://github.com/facebookincubator/nvdtools/assets/30515297/5c12e01a-ba18-4c96-94b6-ded1d702b092)
